### PR TITLE
Fix double link in orchestrations page

### DIFF
--- a/amperity_reference/source/orchestrations.rst
+++ b/amperity_reference/source/orchestrations.rst
@@ -59,7 +59,7 @@ This section describes tasks related to managing orchestrations in Amperity:
 * :ref:`orchestrations-run-scheduled-always-run`
 * :ref:`orchestrations-run-scheduled-wait-for-changes`
 * :ref:`orchestrations-run-unscheduled-wait-for-changes`
-* :ref:`orchestrations-run-unscheduled-wait-for-changes`
+* :ref:`orchestrations-view-notifications`
 
 .. orchestrations-howtos-end
 


### PR DESCRIPTION
## Description

There's a duplicated list item link that points to "Wait for changes" twice [on the orchestrations page](https://docs.amperity.com/reference/orchestrations.html) but I think it should be pointing to "View notifications"

<img width="313" alt="image" src="https://github.com/user-attachments/assets/715da962-088e-45b0-98c2-57c6afaacb61">

## Changes 

<img width="284" alt="image" src="https://github.com/user-attachments/assets/fdf847e3-f280-4a32-b6ca-1040eefa6024">

## Testing

Built/served locally and observed correct link/navigation to "View notifications"

