### PR TITLE
Update source_google_analytics.rst to remove sessionGoogleAdsQuery

### DIFF
--- a/amperity_datagrid/source/source_google_analytics.rst
+++ b/amperity_datagrid/source/source_google_analytics.rst
@@ -143,7 +143,6 @@ The following fields will be available:
 * **date**
 * **deviceCategory**
 * **operatingSystem**
-* **sessionGoogleAdsQuery**
 * **operatingSystemVersion**
 * **sessionMedium**
 * **sessionGoogleAdsAdGroupId**


### PR DESCRIPTION
Removing sessionGoogleAdsQuery from the list of fields we pull since we don't pull it anymore