### PR TITLE
Change the default unified-changes timeout from 30 to 365 days to reflect the current state of the code

### DIFF
--- a/amperity_datagrid/source/configure_stitch.rst
+++ b/amperity_datagrid/source/configure_stitch.rst
@@ -424,7 +424,7 @@ Days of recorded history
 
 .. configure-stitch-general-performance-history-start
 
-You can configure the number of days that are stores for the **Unified Changes PKs** and **Unified Changes Clusters** tables. The default is thirty days.
+You can configure the number of days that are stores for the **Unified Changes PKs** and **Unified Changes Clusters** tables. The default is 365 days.
 
 To update the days of recorded history, open the **Stitch** page, and then click **Stitch settings**. In the list of settings, under **Performance**, update the value of the **Recorded days** field:
 

--- a/amperity_help/source/stitch_config_recorded_days.rst
+++ b/amperity_help/source/stitch_config_recorded_days.rst
@@ -2,6 +2,6 @@
 
 .. tooltip-stitch-config-days-of-recorded-history-start
 
-Amperity stores 30 days of history for unified changes tables, which contain all changes to clusters and primary keys between the current and previous Stitch runs. Changing this setting will not recreate table histories that have already been dropped.
+Amperity stores 365 days of history for unified changes tables, which contain all changes to clusters and primary keys between the current and previous Stitch runs. Changing this setting will not recreate table histories that have already been dropped.
 
 .. tooltip-stitch-config-days-of-recorded-history-end


### PR DESCRIPTION
We changed this to 1 year to make changes more auditable but never updated the docs.