### PR TITLE
Update docs to reflect a new default for bad values

### DIFF
--- a/amperity_datagrid/source/blocklist_bad_values.rst
+++ b/amperity_datagrid/source/blocklist_bad_values.rst
@@ -49,6 +49,7 @@ The default configuration is:
 
    :amperity.stitch.settings/badvalues-config [
    {:threshold 20, :proxy "given-name", :semantic "email"}
+   {:threshold 20, :proxy "surname", :semantic "email"}
    {:threshold 20, :proxy "given-name", :semantic "phone"}
    {:threshold 40, :proxy "given-name", :semantic "address"}]
 


### PR DESCRIPTION
We've added a 4th default to the bad values configuration (https://github.com/amperity/app/pull/48902). This only affects new tenants going forward. I've updated the docs to reflect the new state.

