### PR TITLE
Fix required/optional on endpoint_get_ingest_jobs.rst

### DIFF
--- a/amperity_api/source/endpoint_get_ingest_jobs.rst
+++ b/amperity_api/source/endpoint_get_ingest_jobs.rst
@@ -362,3 +362,4 @@ A **200 OK** response contains the following parameters.
      - The **next_token** parameter is included in the response, but is not available for use with the **ingest/jobs** endpoint. The **ingest/jobs** endpoint only returns a list of ingest jobs that occurred within the previous 7 days.
 
 .. endpoint-get-ingest-jobs-response-parameters-end
+

--- a/amperity_api/source/endpoint_get_ingest_jobs.rst
+++ b/amperity_api/source/endpoint_get_ingest_jobs.rst
@@ -125,9 +125,9 @@ The following table describes the parameters that may be used with the **ingest/
        .. note:: You may use the **api-version** request header instead of the **api_version** request parameter.
 
    * - **created_from**
-     - Datetime. Optional.
+     - Datetime. Required.
 
-       Required. A timestamp that defines the start (inclusive) of a 7-day time window in which one (or more) ingest jobs started. See the **created_to** request parameter.
+       A timestamp that defines the start (inclusive) of a 7-day time window in which one (or more) ingest jobs started. See the **created_to** request parameter.
 
        This timestamp may be a partial timestamp, such as YYYY-MM-DD. The timestamp must be in |ext_iso_8601| format and is in Coordinated Universal Time (UTC).
 
@@ -135,9 +135,9 @@ The following table describes the parameters that may be used with the **ingest/
 
 
    * - **created_to**
-     - Datetime. Optional.
+     - Datetime. Required.
 
-       Required. A timestamp that defines the end (exclusive) of a 7-day time window in which one (or more) ingest jobs started. See the **created_from** request parameter.
+       A timestamp that defines the end (exclusive) of a 7-day time window in which one (or more) ingest jobs started. See the **created_from** request parameter.
 
        This timestamp may be a partial timestamp, such as YYYY-MM-DD. The timestamp must be in |ext_iso_8601| format and is in Coordinated Universal Time (UTC).
 


### PR DESCRIPTION
The created_from and created_to parameters stated they were both optional and required.  In a quick test they appear to both be required (not including both results in error 400 "missing-required-key") so I am editing these to mark them as required parameters for this endpoint