### PR TITLE
Default classifier to sk-unmatch

### DIFF
--- a/amperity_datagrid/source/configure_stitch.rst
+++ b/amperity_datagrid/source/configure_stitch.rst
@@ -241,7 +241,7 @@ Matching strategy
 
 The matching strategy classifier tells Stitch how to apply the results of the blocking strategies, including which groups to analyze and the order in which that analysis should take place, when foreign keys and separation keys are present.
 
-The default behavior :ref:`prioritizes foreign keys over separation keys <semantics-key-foreign-prioritize-matching>`.
+The default behavior :ref:`prioritizes separation keys over foreign keys <semantics-key-separation-prioritize-unmatching>`.
 
 .. configure-stitch-general-clustering-matching-strategy-end
 

--- a/amperity_datagrid/source/semantics.rst
+++ b/amperity_datagrid/source/semantics.rst
@@ -1470,7 +1470,7 @@ The matching strategy classifier tells Amperity how to apply the results of bloc
 
 .. semantics-key-separation-prioritize-unmatching-default-start
 
-The default behavior :ref:`prioritizes foreign key matching <semantics-key-foreign-prioritize-matching>`. Amperity derives separation keys for **sk-given-name** and **sk-generational-suffix**. You may configure Amperity to prioritize separation keys over foreign keys.
+The default behavior :ref:`prioritizes separation key unmatching <semantics-key-separation-prioritize-unmatching>`. Amperity derives separation keys for **sk-given-name** and **sk-generational-suffix**. You may configure Amperity to prioritize foreign keys over separation keys.
 
 .. semantics-key-separation-prioritize-unmatching-default-end
 

--- a/amperity_help/source/stitch_config_matching_classifier.rst
+++ b/amperity_help/source/stitch_config_matching_classifier.rst
@@ -2,6 +2,6 @@
 
 .. tooltip-stitch-config-matching-classifier-start
 
-Amperity prioritizes separation key unmatching over foreign key matching. This determines how Amperity applies the results of your blocking strategies when foreign keys are present. You may prioritize foreign key matching over separation key unmatching.
+Amperity prioritizes separation key unmatching over foreign key matching. This determines how Amperity applies the results of your blocking strategies when separation keys are present. You may configure Amperity to prioritize foreign key matching over separation key unmatching.
 
 .. tooltip-stitch-config-matching-classifier-end

--- a/amperity_help/source/stitch_config_matching_classifier.rst
+++ b/amperity_help/source/stitch_config_matching_classifier.rst
@@ -2,6 +2,6 @@
 
 .. tooltip-stitch-config-matching-classifier-start
 
-Amperity prioritizes foreign key matching over separation key unmatching. This determines how Amperity applies the results of your blocking strategies when foreign keys are present. You may prioritize separation key unmatching over foreign key matching.
+Amperity prioritizes separation key unmatching over foreign key matching. This determines how Amperity applies the results of your blocking strategies when foreign keys are present. You may prioritize foreign key matching over separation key unmatching.
 
 .. tooltip-stitch-config-matching-classifier-end


### PR DESCRIPTION
By default the classifier is now sk-unmatch, not fk-match

I just did a swap on the names but do we want to make a change to how this section reads in stitch_config_matching_classifier? 

"This determines how Amperity applies the results of your blocking strategies when foreign keys are present."

Also there may be some room for de-duplication here since we use similar blocks of texts in two different places. 