### PR TITLE
Update docs to with updated nonbinary-inclusive gender normalization

### DIFF
--- a/amperity_reference/source/semantics.rst
+++ b/amperity_reference/source/semantics.rst
@@ -1807,6 +1807,12 @@ The following table lists the tags available to this semantic group:
        * MAN (is normalized to M)
        * NONE (is treated as NULL)
        * WOMAN (is normalized to F)
+       * X
+       * NONBINARY (is normalized to X)
+       * NON-BINARY (is normalized to X)
+       * ENBY (is normalized to X)
+       * NB (is normalized to X)
+       * OTHER (is normalized to X)
 
    * - **generational-suffix**
      - String


### PR DESCRIPTION
This is based on the changes here: https://github.com/amperity/app/pull/49269

Background from that PR description:
X is a [federally](https://travel.state.gov/content/travel/en/passports/need-passport/selecting-your-gender-marker.html) (and state) recognized gender marker, most often used by nonbinary people.

This change intends to be a minor improvement to better matching people who use the X gender marker or other ways of representing nonbinary gender identity, to support better matching signal across records where that exists.

This mapping is a starting point. Note: not everyone who identifies as nonbinary uses an X marker, and not everyone who uses an X gender marker uses the label nonbinary. However, making some small assumptions here could help with better matching across records where otherwise the normalization function would just be returning nil.

Side note: I discussed this change with some trans* engineers in the #lgbtq-private channel.