### PR TITLE
Updated the spark SQL link

### DIFF
--- a/tokens/external_links.txt
+++ b/tokens/external_links.txt
@@ -2096,7 +2096,7 @@
 
 .. |ext_sparksql_version_current| raw:: html
 
-   <a href="https://archive.apache.org/dist/spark/docs/3.1.2/" target="_blank">Spark SQL, version 3.1.2</a> <i class="fas fa-external-link-square-alt"></i>
+   <a href="https://archive.apache.org/dist/spark/docs/3.1.2/api/sql/index.html" target="_blank">Spark SQL, version 3.1.2</a> <i class="fas fa-external-link-square-alt"></i>
 
 
 .. |ext_sql_workbench| raw:: html


### PR DESCRIPTION
Now it goes directly to the API reference for Spark SQL 3.1.2