### PR TITLE
Remove incorrect info about customer keys from docs site

### DIFF
--- a/amperity_reference/source/semantics.rst
+++ b/amperity_reference/source/semantics.rst
@@ -800,7 +800,6 @@ Customer keys (ck)
 
    * Records may have NULL customer keys.
    * There may be only one customer key per data source.
-   * There may be multiple customer keys per Amperity ID. This is because customer keys may also be tagged as foreign keys.
 
 .. semantics-key-customer-tip-end
 


### PR DESCRIPTION
Removes some incorrect info about customer keys from docs site. See [here](https://amperity.slack.com/archives/C029LR4U3CH/p1736289805370659?thread_ts=1736285414.875279&cid=C029LR4U3CH) 

> Me: CKs also link records if you’ve got transitive FK matches per this from the docs site:
> 
> Docs: There may be multiple customer keys per Amperity ID. This is because customer keys may also be tagged as foreign keys.
> 
> Joe: To my read, that’s wrong. This may be referring to interaction tables that get linked via FKs but that happens outside of stitch and those linked records won’t show up in unified_coalesced.