### PR TITLE
Update max streaming ingest payload

### DIFF
--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -1,6 +1,6 @@
-.. 
+..
 .. https://docs.amperity.com/datagrid/
-.. 
+..
 
 .. |source-name| replace:: Streaming Ingest
 .. |plugin-name| replace:: Streaming Ingest
@@ -386,7 +386,7 @@ The Streaming Ingest API has the following HTTP status codes:
    * - **413**
      - Request is too large.
 
-       .. note:: Amperity limits the maximum payload size to 254 kb.
+       .. note:: Amperity limits the maximum payload size to 500 kb.
      - No
    * - **429**
      - Request throttled.

--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -1,6 +1,6 @@
-..
+.. 
 .. https://docs.amperity.com/datagrid/
-..
+.. 
 
 .. |source-name| replace:: Streaming Ingest
 .. |plugin-name| replace:: Streaming Ingest


### PR DESCRIPTION
Per https://github.com/amperity/app/blob/2b11f07e23b70ccbe48323f8395cb1209049b03d/service/streaming-ingest/streaming-ingest-api/src/amperity/streaming_ingest_api/handler/data.clj#L20 - streaming ingest max payload has been increased, so updating the docs to reflect that.