### PR TITLE
Add more detail to autobv address groups

### DIFF
--- a/amperity_datagrid/source/blocklist_bad_values.rst
+++ b/amperity_datagrid/source/blocklist_bad_values.rst
@@ -781,7 +781,13 @@ When **address** is added to the bad-values blocklist, be sure to verify that re
 
 An effective bad-values blocklist for **address** often requires tuning and validation of the results to ensure that the right level of values are removed from the data. Start with a high threshold (at least "40", but higher if necessary) for **address**, verify the results, and then adjust the threshold carefully until the desired level of accuracy is achieved. Use an Internet search to help verify each address that is blocklisted as part of the verification process.
 
-When the bad-values blocklist is applied to **address** keep in mind that it also considers **city** and **state** along with **address** before determining if the threshold is met.
+When the bad-values blocklist is applied to **address** keep in mind that it also considers **city** and **state** along with **address** before determining if the threshold is met. This group of **city**, **state** and **address** do not replace the **address** value on **Stitch_BadValues**. When multiple addresses are tagged on a table the group for each ordinal address will be checked.
+
+.. ordinal-addresses-tip-start
+
+.. tip:: For more information about **address groups** review the |apply_ordinals_to_address_groups| section in the **Applying semantic tags** topic.
+
+.. ordinal-addresses-tip-end
 
 .. bad-values-blocklist-advanced-addresses-context-end
 

--- a/amperity_datagrid/source/blocklist_bad_values.rst
+++ b/amperity_datagrid/source/blocklist_bad_values.rst
@@ -781,7 +781,7 @@ When **address** is added to the bad-values blocklist, be sure to verify that re
 
 An effective bad-values blocklist for **address** often requires tuning and validation of the results to ensure that the right level of values are removed from the data. Start with a high threshold (at least "40", but higher if necessary) for **address**, verify the results, and then adjust the threshold carefully until the desired level of accuracy is achieved. Use an Internet search to help verify each address that is blocklisted as part of the verification process.
 
-When the bad-values blocklist is applied to **address** keep in mind that it also considers **city** and **state** along with **address** before determining if the threshold is met. This group of **city**, **state** and **address** do not replace the **address** value on **Stitch_BadValues**. When multiple addresses are tagged on a table the group for each ordinal address will be checked.
+When the bad-values blocklist is applied to **address** keep in mind that it also considers **city** and **state** along with **address** before determining if the threshold is met. This group of **city**, **state** and **address** do not replace the **address** value on **Stitch_BadValues**. When multiple addresses are tagged each ordinal address group will be checked.
 
 .. ordinal-addresses-tip-start
 

--- a/tokens/internal_links.txt
+++ b/tokens/internal_links.txt
@@ -66,6 +66,11 @@
    <a href="https://docs.amperity.com/datagrid/api_streaming_ingest.html">Streaming Ingest API</a>
 
 
+.. |apply_ordinals_to_address_groups| raw:: html
+
+   <a href="https://docs.amperity.com/datagrid/semantics.html#apply-ordinals-to-address-groups">Apply ordinals to address groups</a>
+
+
 .. |attribute_compound_first_order| raw:: html
 
    <a href="https://docs.amperity.com/reference/attribute_compound_first_order.html">First Order</a>


### PR DESCRIPTION
Some confusion occurred due to this being vague. 

- Adds a lot more nuance
- Add link to ordinal address group info

https://amperity.atlassian.net/browse/IDE-2424

Question: Did I setup the link & tip correctly?