### PR TITLE
[FISH-1577] Segments used doc update

### DIFF
--- a/amperity_reference/source/usage.rst
+++ b/amperity_reference/source/usage.rst
@@ -39,7 +39,7 @@ The **Activations** section in the **Usage** dashboard contains the following :r
    Shows the total number of segments that are available during the selected time period. This number is compared to the number of segments that were available during the previous time period.
 
 **Segments used**
-   Shows the total number of segments that have been used in a campaign---including delivered and scheduled campaigns---as of the last date in the selected time period. This number is compared to the number of segments that were used in campaigns during the previous time period.
+   Shows the total number of segments that are in use by a campaign that ran during the selected time period. This number is compared to the number of segments that were used by campaigns that ran during the previous time period.
 
 along with the following graphs:
 


### PR DESCRIPTION
Our users were confused by the "Segments in Use" card on the usage page. We made a change to how we calculate that metric to align closer with user expectation. Previously all campaigns were considered when counting segments configured to a campaign. Now we only consider campaigns that actually ran during the time period selected on the page.