### PR TITLE
Fix misalignment in SK examples

### DIFF
--- a/amperity_amp360/source/index.rst
+++ b/amperity_amp360/source/index.rst
@@ -18,7 +18,6 @@ About Amperity
 ==================================================
 
 
-
 .. _index-review-id-resolution:
 
 Review ID resolution

--- a/amperity_datagrid/source/semantics.rst
+++ b/amperity_datagrid/source/semantics.rst
@@ -1421,7 +1421,7 @@ Assign a unique separation key to each primary key to prevent clusters from bein
       * - etc.
         - ...
 
-When **sk-acme** and **sk-acmedulxe** appear in the same cluster, they will be scored as non-matching and the records will be separated.
+When **sk-brand-acme** and **sk-brand-acme-deluxe** appear in the same cluster, they will be scored as non-matching and the records will be separated.
 
 * Records with the same brand share a separation key, but those values are guaranteed to be different because they are primary keys.
 * Records with different brands will have no non-**NULL** separation keys in common and will use the standard classifier.


### PR DESCRIPTION
The examples and commentary don't align
<img width="829" alt="Screenshot 2025-01-21 at 8 46 57 AM" src="https://github.com/user-attachments/assets/441e817b-ad6b-43bc-a9f3-20ce6a59df2b" />
