### PR TITLE
Update max streaming ingest size

### DIFF
--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -385,7 +385,7 @@ The Streaming Ingest API has the following HTTP status codes:
    * - **413**
      - Request is too large.
 
-       .. note:: Amperity limits the maximum payload size to 500 kb.
+       .. note:: Amperity limits the maximum payload size to 5MB.
      - No
    * - **429**
      - Request throttled.


### PR DESCRIPTION
Per: https://github.com/amperity/app/pull/51867, streaming ingest now supports files up to 5mb instead of 500kb.