### PR TITLE
Add rate limit section to streaming ingest doc

### DIFF
--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -52,6 +52,22 @@ A stream may only be one payload type.
 .. streaming-ingest-rest-api-overview-end
 
 
+.. _streaming-ingest-limits:
+
+Limits
+==================================================
+
+.. streaming-ingest-limits-start
+
+The Streaming Ingest API has the following limits, all set at the tenant level (sandboxes are their own separate tenants):
+
+Requests per second: 1000 requests per second (rps). You will receive a 429 Too Many Requests response when this is exceeded. No additional burst capacity beyond 1000 rps is currently supported.
+
+Payload size: 5 MB maximum. You will receive a 413 Payload Too Large response when this is exceeded.
+
+.. streaming-ingest-limits-end
+
+
 .. _streaming-ingest-rest-api-keys-and-jwt:
 
 API Keys and JWTs
@@ -390,7 +406,7 @@ The Streaming Ingest API has the following HTTP status codes:
    * - **429**
      - Request throttled.
 
-       .. note:: The request limit is set above the expected traffic volume.
+       .. note:: Amperity limits streaming ingest to 1000rps.
      - Yes
    * - **500**
      - Internal error.

--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -52,20 +52,32 @@ A stream may only be one payload type.
 .. streaming-ingest-rest-api-overview-end
 
 
-.. _streaming-ingest-limits:
+.. _streaming-ingest-rate-limits:
 
-Limits
+Rate limits
 ==================================================
 
-.. streaming-ingest-limits-start
+.. streaming-ingest-rate-limits-start
 
-The Streaming Ingest API has the following limits, all set at the tenant level (sandboxes are their own separate tenants):
+The Streaming Ingest API has the following rate limits.
 
-Requests per second: 1000 requests per second (rps). You will receive a 429 Too Many Requests response when this is exceeded. No additional burst capacity beyond 1000 rps is currently supported.
+.. note:: Rate limits are not shared between production and sandboxes; each sandbox has its own rate limit.
 
-Payload size: 5 MB maximum. You will receive a 413 Payload Too Large response when this is exceeded.
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
 
-.. streaming-ingest-limits-end
+   * - **Requests per second**
+     - The number of requests may not exceed 1000 requests per second.
+
+       Requests to the Streaming Ingest API that exceed 1000 requests per second will return an error response with an HTTP 429 Too Many Requests status code.
+
+   * - **Payload size**
+     - The maximim payload size may not exceed 5 MB.
+
+       Attempts to post more than 5 MB will fail with an HTTP 413 Payload Too Large status code. 
+
+.. streaming-ingest-rate-limits-end
 
 
 .. _streaming-ingest-rest-api-keys-and-jwt:
@@ -401,12 +413,12 @@ The Streaming Ingest API has the following HTTP status codes:
    * - **413**
      - Request is too large.
 
-       .. note:: Amperity limits the maximum payload size to 5MB.
+       .. note:: The maximim payload size :ref:`may not exceed 5 MB <streaming-ingest-rate-limits>`.
      - No
    * - **429**
      - Request throttled.
 
-       .. note:: Amperity limits streaming ingest to 1000rps.
+       .. note:: The number of requests :ref:`may not exceed 1000 requests per second <streaming-ingest-rate-limits>`.
      - Yes
    * - **500**
      - Internal error.

--- a/amperity_datagrid/source/api_streaming_ingest.rst
+++ b/amperity_datagrid/source/api_streaming_ingest.rst
@@ -73,9 +73,9 @@ The Streaming Ingest API has the following rate limits.
        Requests to the Streaming Ingest API that exceed 1000 requests per second will return an error response with an HTTP 429 Too Many Requests status code.
 
    * - **Payload size**
-     - The maximim payload size may not exceed 5 MB.
+     - The maximum payload size may not exceed 5 MB.
 
-       Attempts to post more than 5 MB will fail with an HTTP 413 Payload Too Large status code. 
+       Attempts to post more than 5 MB will fail with an HTTP 413 Payload Too Large status code.
 
 .. streaming-ingest-rate-limits-end
 
@@ -413,7 +413,7 @@ The Streaming Ingest API has the following HTTP status codes:
    * - **413**
      - Request is too large.
 
-       .. note:: The maximim payload size :ref:`may not exceed 5 MB <streaming-ingest-rate-limits>`.
+       .. note:: The maximum payload size :ref:`may not exceed 5 MB <streaming-ingest-rate-limits>`.
      - No
    * - **429**
      - Request throttled.


### PR DESCRIPTION
We have added limit enforcement into the streaming ingest API! So we should probably document them in a highly visible place in the docs.
<img width="462" alt="image" src="https://github.com/user-attachments/assets/5bae0b68-9647-435f-a320-684230199fd0" />

