### PR TITLE
new understanding of profile-api costs

### DIFF
--- a/amperity_reference/source/amps.rst
+++ b/amperity_reference/source/amps.rst
@@ -319,6 +319,7 @@ Amps consumption for the **Profile API** feature is determined by:
 Monitor Amps consumption for the **Profile API** feature by:
 
 * Ensuring that your tenant generates Profile API indexes that are necessary to support your downstream workflows.
+
 .. amps-consumption-feature-profile-api-end
 
 

--- a/amperity_reference/source/amps.rst
+++ b/amperity_reference/source/amps.rst
@@ -314,16 +314,11 @@ Profile API
 
 Amps consumption for the **Profile API** feature is determined by:
 
-* The number of individual Profile API indexes that are enabled in your tenant; each index is made available as an endpoint that is always available to downstream workflows that make API requests to that endpoint
-* The frequency at which each Profile API index is refreshed
-* The width of each Profile API index (where width refers to the number of columns, or response parameters, that are available in the index; wider indexes consume more Amps)
-* The number of indexes that are refreshed automatically by a courier group
+* The number of individual Profile API indexes that are enabled in your tenant; each index is made available as an endpoint that is always available to downstream workflows that make API requests to that endpoint.
 
 Monitor Amps consumption for the **Profile API** feature by:
 
-* Ensuring that your tenant generates Profile API indexes that are necessary to support your downstream workflows, including not only the number of indexes, but also including the amount data that is made available from each index; Amps consumption is affected by the length of time it takes to run the query to generate the index and also the number of fields that are added to the index. `Complex queries will consume more Amps; queries that return large numbers of columns and/or rows will consume more Amps <https://docs.amperity.com/datagrid/api_profile.html#index-response-times>`__
-* Monitoring the history of Profile API index refreshes from the **Workflows** page
-
+* Ensuring that your tenant generates Profile API indexes that are necessary to support your downstream workflows.
 .. amps-consumption-feature-profile-api-end
 
 


### PR DESCRIPTION
Learned that amps usage for profile api is like 99.3% from just the number of indices. Refresh frequency, index width, and query complexity have basically no impact.

thread: https://amperity.slack.com/archives/C07UL0MSC3Z/p1744228651632859
