### PR TITLE
Fix the information about full-name on unified_coalesced

### DIFF
--- a/amperity_reference/source/data_tables.rst
+++ b/amperity_reference/source/data_tables.rst
@@ -3335,8 +3335,8 @@ The **Unified Coalesced** table contains the following columns:
    * - **Full Name**
      - String
      - .. include:: ../../shared/terms.rst
-          :start-after: .. term-full-name-start
-          :end-before: .. term-full-name-end
+          :start-after: .. term-full-name-unified-coalesced-start
+          :end-before: .. term-full-name-unified-coalesced-end
 
        Values in this column depend on fields that are tagged with the **Full Name** semantic.
 

--- a/amperity_reference/source/data_tables.rst
+++ b/amperity_reference/source/data_tables.rst
@@ -1344,8 +1344,8 @@ The **Merged Customers** table contains the following columns:
    * - **Full Name**
      - String
      - .. include:: ../../shared/terms.rst
-          :start-after: .. term-full-name-start
-          :end-before: .. term-full-name-end
+          :start-after: .. term-full-name-unified-coalesced-start
+          :end-before: .. term-full-name-unified-coalesced-end
 
        Also in: **Unified Coalesced**, **Unified Customer**
 
@@ -3338,8 +3338,6 @@ The **Unified Coalesced** table contains the following columns:
           :start-after: .. term-full-name-unified-coalesced-start
           :end-before: .. term-full-name-unified-coalesced-end
 
-       Values in this column depend on fields that are tagged with the **Full Name** semantic.
-
        Also in: **Merged Customers**, **Unified Customer**
 
    * - **Gender**
@@ -3800,10 +3798,8 @@ The **Unified Customer** table contains the following columns:
    * - **Full Name**
      - String
      - .. include:: ../../shared/terms.rst
-          :start-after: .. term-full-name-start
-          :end-before: .. term-full-name-end
-
-       Values in this column depend on fields that are tagged with the **full-name** semantic.
+          :start-after: .. term-full-name-unified-coalesced-start
+          :end-before: .. term-full-name-unified-coalesced-end
 
        Also in: **Merged Customers**, **Unified Coalesced**
 

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -2815,11 +2815,12 @@ A combination of given name (first name) and surname (last name) for a customer.
 
 .. term-full-name-unified-coalesced-start
 
-A combination of given name (first name) and surname (last name) for a customer. Can be populated in four ways, the first non-nil value will be selected:
-#. A value tagged with `full-name`
-#. A concatenation values tagged with `given-name` and `surname` if they both exist
-#. A value tagged with `given-name`
-#. A value tagged with `surname`
+A combination of given name (first name) and surname (last name) for a customer. Can be populated in the following ways; the first non-nil value will be selected:
+
+#. A value tagged with ``full-name``.
+#. A concatenation of values tagged with ``given-name`` and ``surname`` if they both exist.
+#. A value tagged with ``given-name``.
+#. A value tagged with ``surname``.
 
 .. term-full-name-unified-coalesced-end
 

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -2811,6 +2811,17 @@ A combination of given name (first name) and surname (last name) for a customer.
 
 .. term-full-name-ampid-end
 
+- or -
+
+.. term-full-name-unified-coalesced-start
+
+A combination of given name (first name) and surname (last name) for a customer. Can be populated in four ways, the first non-nil value will be selected:
+#. A value tagged with `full-name`
+#. A concatenation values tagged with `given-name` and `surname` if they both exist
+#. A value tagged with `given-name`
+#. A value tagged with `surname`
+
+.. term-full-name-unified-coalesced-end
 
 **gender**
 


### PR DESCRIPTION
We had a HALP occur because full-name doesn't behave like you would export or like we've documented. It is actually a coalesce of four values: full-name, given-name+surname, given-name, surname (the SQL isn't written that way but its the same outcome and easier to understand as a coalesce)

Jira: https://amperity.atlassian.net/browse/IDE-2660

https://github.com/amperity/app/blob/main/service/stitch/stitch/src/amperity/stitch/views/unified_coalesced.clj#L382-L394