### PR TITLE
Add Google ECL instructions to Offline Events Google ECL docs

### DIFF
--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -7,6 +7,7 @@
 .. |attributes-sent| replace:: |destination-name| requires first-party data that is associated with transactions.
 .. |where-send| replace:: |destination-name|
 .. |required-credentials| replace:: "Customer ID"
+.. |credential-type| replace:: "google-ads"
 
 
 .. meta::

--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -9,6 +9,7 @@
 .. |required-credentials| replace:: "Customer ID"
 .. |credential-type| replace:: "google-ads"
 .. |filter-the-list| replace:: "google"
+.. |plugin-name| replace:: "Google Enhanced Conversions"
 
 
 .. meta::

--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -8,6 +8,7 @@
 .. |where-send| replace:: |destination-name|
 .. |required-credentials| replace:: "Customer ID"
 .. |credential-type| replace:: "google-ads"
+.. |filter-the-list| replace:: "google"
 
 
 .. meta::

--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -6,6 +6,7 @@
 .. |what-enablex| replace:: **email**
 .. |attributes-sent| replace:: |destination-name| requires first-party data that is associated with transactions.
 .. |where-send| replace:: |destination-name|
+.. |required-credentials| replace:: "Customer ID"
 
 
 .. meta::

--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -5,6 +5,7 @@
 .. |what-send| replace:: first-party customer data that is associated with transactions
 .. |what-enablex| replace:: **email**
 .. |attributes-sent| replace:: |destination-name| requires first-party data that is associated with transactions.
+.. |where-send| replace:: |destination-name|
 
 
 .. meta::

--- a/amperity_ampiq/source/events_google_enhanced_conversions.rst
+++ b/amperity_ampiq/source/events_google_enhanced_conversions.rst
@@ -32,6 +32,226 @@ Send offline events to Google Enhanced Conversions
    :end-before: .. destination-google-enhanced-conversions-about-end
 
 
+.. _destination-google-enhanced-conversions-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-google-enhanced-conversions-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: left
+          :class: no-scaled-link
+     - **Configure Google Ads**
+
+       Enable enhanced conversions for leads in Google Ads:
+
+       #. `Enable conversion tracking in Google Ads <https://developers.google.com/google-ads/api/docs/conversions/enhanced-conversions/leads-setup>`__ |ext_link|.
+       #. Accept customer data terms and opt-in to enhanced conversions for leads.
+       #. Set up tagging through Google Tag Manager.
+       #. Create at least one ConversionAction.
+
+          The conversion_action_type must be set to **UPLOAD_CLICKS**.
+
+       #. `Configure Google tag settings <https://support.google.com/google-ads/answer/11021502#configure>`__ |ext_link| to enable enhanced conversions for leads.
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: left
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **Refresh token**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oauth-refresh-token-start
+             :end-before: .. credential-oauth-refresh-token-end
+
+          .. important:: Authentication for "Google Enhanced Conversions" *must* be completed within Google prior to configuring Amperity to send ads to |destination-name|.
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: left
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Customer ID**
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-google-enhanced-conversions-customer-id-start
+             :end-before: .. setting-google-enhanced-conversions-customer-id-end
+
+.. destination-google-enhanced-conversions-get-details-table-end
+
+
+.. _destination-google-enhanced-conversions-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure OAuth**
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step 1.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step 2.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step 3.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **Refresh token**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oauth-refresh-token-start
+             :end-before: .. credential-oauth-refresh-token-end
+
+.. destination-google-enhanced-conversions-credentials-steps-end
+
+
+.. _destination-google-enhanced-conversions-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Google Enhanced Conversions**
+
+.. destination-google-enhanced-conversions-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step 1.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step 2.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step 3.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step 4.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Conversion action name** (Required at orchestration)
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-google-enhanced-conversions-action-name-start
+             :end-before: .. setting-google-enhanced-conversions-action-name-end
+
+       **Customer ID**
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-google-enhanced-conversions-customer-id-start
+             :end-before: .. setting-google-enhanced-conversions-customer-id-end
+
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step 5.
+          :align: left
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-orchestration-only-start
+          :end-before: .. destinations-steps-business-users-orchestration-only-end
+
+.. destination-google-enhanced-conversions-add-steps-end
+
+
 .. _events-google-enhanced-conversions-build-query:
 
 Build a query


### PR DESCRIPTION
It looks like there was already documentation prepared for configuring a Google ECL destination/credentials/etc... The customer ask was that this be exposed on this page https://docs.amperity.com/ampiq/events_google_enhanced_conversions.html so that is what this PR does! 

Please let me know if I'm off base here. 