### PR TITLE
Update Meta CAPI connector docs for DART-1103

### DIFF
--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -448,7 +448,9 @@ The fields are listed alphabetically, but may be returned by a query in any orde
        **website**
          Use when the offline conversion was made on a website.
 
-         When **action_source** is set to **website** the following fields are required: **client_user_agent**, **event_id**, and **event_source_url**. These fields must be in the results that are sent to |destination-name|. Missing or empty values are filtered from the results.
+         When **action_source** is set to **website** the following fields are required: **client_ip_address**, **client_user_agent**, **event_id**, and **event_source_url**. These fields must be in the results that are sent to |destination-name|. Missing or empty values are filtered from the results.
+
+         * The value for **client_ip_address** must be the IP address of the browser corresponding to the event.
 
          * The value for **client_user_agent** must be the user agent for the browser corresponding to the event.
 
@@ -456,16 +458,16 @@ The fields are listed alphabetically, but may be returned by a query in any orde
 
          * The value for **event_source_url** should be browser URL at which the event occurred.
 
-         **event_id** and **event_source_url** are `server event parameters <https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event/>`__ |ext_link| for the Conversions API.
+         **event_id**, **event_source_url**, **client_user_agent**, and **client_ip_address** are `server event parameters <https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event/>`__ |ext_link| for the Conversions API.
 
        The value for **action_source** is used by the Conversions API to categorize offline conversions within the |destination-name| user interface and may not be customized. Use the action source that best associates how your brand wants to use offline conversions within |destination-name|.
 
        When **action_source** is not specified the default value is "physical_store".
 
    * - **currency**
-     - **Required**
+     - **Required for Purchase events**
 
-       A value for **currency** is required by the Conversions API for events. Currency must be a valid |ext_iso_4217| three-digit currency code, such as "USD" (United States dollar), "AUD" (Australian dollar), "CAD" (Canadian dollar), "EUR" (Euro), "JPY" (Japanese yen) or "MXN" (Mexican peso).
+       A value for **currency** is required by the Conversions API for Purchase events. When the **event_name** column is present in the dataset, **currency** is only required for rows where the event name is "Purchase" (or blank, which defaults to "Purchase"). When **event_name** is not present, all events are treated as Purchase and **currency** is required. Currency must be a valid |ext_iso_4217| three-digit currency code, such as "USD" (United States dollar), "AUD" (Australian dollar), "CAD" (Canadian dollar), "EUR" (Euro), "JPY" (Japanese yen) or "MXN" (Mexican peso).
 
        Add **currency** to your query, and then set a value:
 
@@ -541,9 +543,9 @@ The fields are listed alphabetically, but may be returned by a query in any orde
      - See **email**.
 
    * - **price**
-     - **Required**
+     - **Required for Purchase events**
 
-       The price that is associated with the offline event.
+       The price that is associated with the offline event. When the **event_name** column is present in the dataset, **price** is only required for Purchase events. Non-purchase events (such as Lead) do not require **price**.
 
        .. note:: When viewing parameters in the |destination-name| user interface, **price**, **quantity**, and **currency** are combined to be shown as **value**, which represents the sum of price times quantity, shown in the currency used for the transaction.
 
@@ -573,9 +575,9 @@ The fields are listed alphabetically, but may be returned by a query in any orde
 
 
    * - **quantity** *or* **value**
-     - **Required**
+     - **Required for Purchase events**
 
-       A field that describes a quantity or a value amount associated with the offline event.
+       A field that describes a quantity or a value amount associated with the offline event. When the **event_name** column is present in the dataset, **quantity** (or **value**) is only required for Purchase events. Non-purchase events (such as Lead) do not require **quantity** or **value**.
 
        .. note:: When viewing parameters in the |destination-name| user interface, **price**, **quantity** (or **value**), and **currency** are combined to be shown as **value**, which represents the sum of price times quantity, shown in the currency used for the transaction.
 

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -448,9 +448,7 @@ The fields are listed alphabetically, but may be returned by a query in any orde
        **website**
          Use when the offline conversion was made on a website.
 
-         When **action_source** is set to **website** the following fields are required: **client_ip_address**, **client_user_agent**, **event_id**, and **event_source_url**. These fields must be in the results that are sent to |destination-name|. Missing or empty values are filtered from the results.
-
-         * The value for **client_ip_address** must be the IP address of the browser corresponding to the event.
+         When **action_source** is set to **website** the following fields are required: **client_user_agent**, **event_id**, and **event_source_url**. These fields must be in the results that are sent to |destination-name|. Missing or empty values are filtered from the results.
 
          * The value for **client_user_agent** must be the user agent for the browser corresponding to the event.
 
@@ -458,7 +456,9 @@ The fields are listed alphabetically, but may be returned by a query in any orde
 
          * The value for **event_source_url** should be browser URL at which the event occurred.
 
-         **event_id**, **event_source_url**, **client_user_agent**, and **client_ip_address** are `server event parameters <https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event/>`__ |ext_link| for the Conversions API.
+         **client_ip_address** is an optional field that, when present, is passed through to Meta. Meta recommends providing it to improve event matching quality. The value must be the IP address of the browser corresponding to the event.
+
+         **event_id**, **event_source_url**, and **client_user_agent** are `server event parameters <https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event/>`__ |ext_link| for the Conversions API.
 
        The value for **action_source** is used by the Conversions API to categorize offline conversions within the |destination-name| user interface and may not be customized. Use the action source that best associates how your brand wants to use offline conversions within |destination-name|.
 

--- a/amperity_user/source/events_meta_ads_manager.rst
+++ b/amperity_user/source/events_meta_ads_manager.rst
@@ -83,7 +83,7 @@ A query that returns a collection events for use in |destination-name| is simila
    LEFT JOIN Customer_360 c360 ON uit.amperity_id = c360.amperity_id
    WHERE uit.order_datetime > (CURRENT_DATE - interval '7' day)
 
-The query **MUST** contain the following fields: **external_id**, **order_id**, **quantity**, **email** or **phone**, **timestamp**, **price**, and **currency**. When **action_source** is not specified the default value is "physical_store".
+The query **MUST** contain the following fields: **email** or **phone** and **timestamp**. For Purchase events (or when **event_name** is not specified), the query must also contain **currency** and either **quantity** and **price**, or **value**. The fields **external_id** and **order_id** are recommended. When **action_source** is not specified the default value is "physical_store".
 
 You may include any of the following customer profile fields to help improve match rates in |destination-name|: **given_name**, **surname**, **birthdate**, **gender**, **city**, **state**, **postal**, and **country**.
 


### PR DESCRIPTION
## Summary
- Add `client_ip_address` as an optional pass-through field for website conversion events (Meta recommends it for improved event matching but does not require it)
- Update `currency`, `price`, and `quantity`/`value` from "Required" to "Required for Purchase events" to reflect new configurable event name support
- Update the user query guide to clarify which fields are always required vs Purchase-specific

[DART-1103]

[DART-1103]: https://amperity.atlassian.net/browse/DART-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ