### PR TITLE
Add az-prod/azure_westus2 Business Critical account locator

### DIFF
--- a/amperity_operator/source/bridge_snowflake.rst
+++ b/amperity_operator/source/bridge_snowflake.rst
@@ -519,8 +519,12 @@ Snowflake must be configured for the correct `account locator IDs <https://docs.
      - BCB42530
 
    * - az-prod
-     - azure_westus2
+     - azure_westus2 (Standard)
      - VU31691
+
+   * - az-prod
+     - azure_westus2 (Business Critical)
+     - BO18496
 
    * - az-prod
      - azure_australiaeast

--- a/amperity_operator/source/bridge_snowflake.rst
+++ b/amperity_operator/source/bridge_snowflake.rst
@@ -519,11 +519,7 @@ Snowflake must be configured for the correct `account locator IDs <https://docs.
      - BCB42530
 
    * - az-prod
-     - azure_westus2 (Standard)
-     - VU31691
-
-   * - az-prod
-     - azure_westus2 (Business Critical)
+     - azure_westus2
      - BO18496
 
    * - az-prod


### PR DESCRIPTION
## Summary

Replaces the existing `az-prod / azure_westus2` custodial Snowflake account locator with the new Business Critical edition locator `BO18496`. The previous Standard locator (`VU31691`) still works for existing tenants, but is no longer the default for new onboardings and no longer needs to live in public docs.

Jira ticket: [STORM-2941]
Paired repo PR: amperity/app#67183 (merged — registered the new BC account in `config.edn` + Terraform, promoted it to `:default` in that region).

## Changes

`amperity_operator/source/bridge_snowflake.rst`:
- `az-prod / azure_westus2` locator changed from `VU31691` to `BO18496`.

## Context

The new BC-edition account (`amperity_bridge_zpzwu2_ab8v`) is now the default for any bridge provisioned in `az-prod / azure_westus2`. Rare Standard-edition customers in this region will be routed via the existing support note at the bottom of the table.

[STORM-2941]: https://amperity.atlassian.net/browse/STORM-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ