### PR TITLE
remove warning about mcp urls

### DIFF
--- a/amperity_api/source/mcp_setup_chatgpt.rst
+++ b/amperity_api/source/mcp_setup_chatgpt.rst
@@ -61,8 +61,6 @@ To add the Amperity MCP server to ChatGPT:
 
       https://mcp.amperity.com
 
-   .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` for this setting.
-
 #. Set the authentication type to **OAuth**. Use **nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs** as the OAuth client ID.
 #. Save the connector. A browser tab opens. Sign in with your Amperity OAuth credentials.
 #. Enable the Amperity connector for any chat session.

--- a/amperity_api/source/mcp_setup_claude.rst
+++ b/amperity_api/source/mcp_setup_claude.rst
@@ -63,8 +63,6 @@ Claude.ai is the canonical location to add remote MCP connectors. Once added, th
 
       https://mcp.amperity.com
 
-   .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` for this setting.
-
    Use **nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs** as the OAuth client ID.
 
 #. Click **Add**. A browser tab opens. Sign in with your Amperity OAuth credentials.
@@ -90,8 +88,6 @@ Configure the Amperity MCP server for Claude Code.
    .. code-block:: bash
 
       claude mcp add --transport http --scope user amperity https://mcp.amperity.com
-
-   .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` in the command.
 
    The server is registered in your user-scoped Claude configuration and is available in every Claude Code session.
 
@@ -130,7 +126,5 @@ Claude calls the **tenant_info** tool and return details about your current Ampe
       claude mcp remove amperity
 
       claude mcp add --transport http --scope user amperity https://mcp.amperity.com
-
-      .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` in the command.
 
 .. mcp-setup-claude-interacting-end

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -73,8 +73,6 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
       * - **Server URL**
         - **https://mcp.amperity.com**
 
-          .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` in the command.
-
 #. Under **Authentication**, select **OAuth 2.0**.
 
    Choose the **Manual** type and fill in the following fields.
@@ -95,8 +93,6 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
         - **https://mcp.amperity.com/oauth/token**
       * - **Refresh URL**
         - **https://mcp.amperity.com/oauth/token**
-
-   .. important:: Use the :ref:`correct MCP server URL <mcp-overview-mcp-urls>` in the command, and then append **/authorize** and **/oauth/token** to that URL for the **Authorization URL**, **Token URL template**, and **Refresh URL** values.
 
 #. Select **Create**. **Copilot Studio** displays a callback URL. The Amperity OAuth proxy registers the callback URL dynamically.
 


### PR DESCRIPTION
## Summary

in https://github.com/amperity/amperity-docs/pull/823, docs were updated to note that the MCP is stack-agnostic now. Now we can remove the "important" callouts in the individual pages.