### PR TITLE
AI-1970: Update MCP docs (default toolset, tool reference, client IDs)

### DIFF
--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -57,7 +57,7 @@ The MCP server enables:
 
 * More than 200 tools across tenants, such as databases, queries, identity resolution, campaigns, and predictive modeling. This full toolset is the default for connected clients.
 
-  .. note:: Some clients, such as Copilot Studio, limit the number of individual tools an agent can register. For these clients, the Amperity MCP server automatically serves a curated subset of tools that fits within the client's limit. See :ref:`Tool surface limits <mcp-setup-copilot-surface-limits>`.
+  .. note:: Copilot Studio limits the number of individual tools an agent can register. For Copilot Studio connections, the Amperity MCP server automatically serves a curated subset of tools that fits within this limit. See :ref:`Tool surface limits <mcp-setup-copilot-surface-limits>`.
 
 * Per-user isolation. Each request is authenticated and scoped to the calling user's identity, tenant, and permissions.
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -55,9 +55,9 @@ The MCP server enables:
 
 * Conversational access to Amperity from Copilot Studio, Claude, ChatGPT, and other MCP-compatible clients.
 
-* More than 200 tools across tenants, such as databases, queries, identity resolution, campaigns, and predictive modeling.
+* More than 200 tools across tenants, such as databases, queries, identity resolution, campaigns, and predictive modeling. This full toolset is the default for connected clients.
 
-  .. note:: Some clients, such as Copilot Studio, limit the number of individual tools an agent can register and may require surfacing only a subset of the full toolset available in the MCP server.
+  .. note:: Some clients, such as Copilot Studio, limit the number of individual tools an agent can register. For these clients, the Amperity MCP server automatically serves a curated subset of tools that fits within the client's limit. See :ref:`Tool surface limits <mcp-setup-copilot-surface-limits>`.
 
 * Per-user isolation. Each request is authenticated and scoped to the calling user's identity, tenant, and permissions.
 

--- a/amperity_api/source/mcp_setup_chatgpt.rst
+++ b/amperity_api/source/mcp_setup_chatgpt.rst
@@ -61,7 +61,11 @@ To add the Amperity MCP server to ChatGPT:
 
       https://mcp.amperity.com
 
-#. Set the authentication type to **OAuth**. Use **nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs** as the OAuth client ID.
+#. Set the authentication type to **OAuth**, and then use the following OAuth client ID:
+
+   .. code-block:: none
+
+      nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs
 #. Save the connector. A browser tab opens. Sign in with your Amperity OAuth credentials.
 #. Enable the Amperity connector for any chat session.
 

--- a/amperity_api/source/mcp_setup_claude.rst
+++ b/amperity_api/source/mcp_setup_claude.rst
@@ -63,7 +63,11 @@ Claude.ai is the canonical location to add remote MCP connectors. Once added, th
 
       https://mcp.amperity.com
 
-   Use **nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs** as the OAuth client ID.
+   Use the following OAuth client ID:
+
+   .. code-block:: none
+
+      nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs
 
 #. Click **Add**. A browser tab opens. Sign in with your Amperity OAuth credentials.
 

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -84,7 +84,9 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
       * - Field
         - Value
       * - **Client ID**
-        - **nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs**
+        - .. code-block:: none
+
+             nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs
       * - **Client secret**
         - Any non-empty placeholder, for example "unused". The Amperity MCP server is a PKCE-based public OAuth client and ignores this value, but **Copilot Studio** requires the field to be non-empty.
       * - **Authorization URL**

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -109,13 +109,13 @@ Tool surface limits
 
 .. mcp-setup-copilot-surface-limits-start
 
-Copilot Studio limits the number of tools an agent can register. The full Amperity MCP surface exposes more than 200 tools, so most agents will need to scope down the number of tools. There are two options:
+Copilot Studio limits the number of tools an agent can register. The full Amperity MCP surface exposes more than 200 tools, which exceeds this limit.
 
-#. Use a persona-scoped MCP server. Amperity publishes split MCP servers that expose a smaller, role-scoped tool surface for clients with tool-count limits. Contact your Amperity representative for access.
+To stay within the limit, the Amperity MCP server automatically detects Copilot Studio connections and serves a curated subset of tools sized to fit within Copilot Studio's connector tool limit. No manual configuration is required--connect Copilot Studio by following the steps above, and your agent receives the curated tool set automatically.
 
-#. Restrict your agent to a subset of tools. On your agent's **Tools** tab, select the Amperity MCP server to open its settings page. Under the **Tools** section, turn off the **Allow all** toggle, and then use the individual toggles to enable only the tools your agent needs.
+To narrow the surface further, restrict your agent to a smaller subset of tools. On your agent's **Tools** tab, select the Amperity MCP server to open its settings page. Under the **Tools** section, turn off the **Allow all** toggle, and then use the individual toggles to enable only the tools your agent needs.
 
-   .. important:: Tools added to the Amperity MCP server are turned off by default when **Allow all** is disabled.
+.. important:: Tools added to the Amperity MCP server are turned off by default when **Allow all** is disabled.
 
 .. mcp-setup-copilot-surface-limits-end
 

--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -51,9 +51,7 @@ Manage which Amperity tenant the current session targets, and read session-level
        **tenant_resync**
 
    * - Manage sandbox tenants
-     - **sandbox_list**
-
-       **sandbox_create**
+     - **sandbox_create**
 
        **sandbox_get_create_status**
 
@@ -477,6 +475,25 @@ Manage campaigns, campaign folders, journeys, and audiences.
 
        **journey_delete**
 
+   * - Manage journey versions
+     - **journey_list_versions**
+
+       **journey_get_version**
+
+       **journey_create_version**
+
+       **journey_update_version**
+
+   * - Run, schedule, and unschedule journeys
+     - **journey_run**
+
+       **journey_schedule**
+
+       **journey_unschedule**
+
+   * - Read a journey's node schema
+     - **journey_get_node_schema**
+
    * - Manage labels
      - **label_list**
 
@@ -801,3 +818,21 @@ Manage alert subscriptions and run training tasks for semantic tagging.
 
    * - Run training tasks for semantic tagging
      - **training_setup_semantic_tags**
+
+
+.. _mcp-tool-deep-links:
+
+Deep links
+==================================================
+
+Build deep-link URLs to Amperity UI pages. Constructed locally, with no API call.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Description
+     - Tools
+
+   * - Build a deep-link URL to an Amperity UI page
+     - **build_object_url**


### PR DESCRIPTION
## Summary

Documents the shipped MCP tier-resolver change (`amperity-mcp` #523, AI-1899) and tidies adjacent MCP docs in the same pass. Bearer MCP sessions now default to the full customer-safe toolset; Copilot Studio is detected automatically and served a curated subset that fits its connector tool cap.

The public docs describe observable behavior rather than the internal `slim`/`external`/`full` tier names:

- **`mcp_overview.rst`** — the full toolset (200+ tools) is now stated as the default; the note calls out Copilot Studio specifically (the only client the server auto-curates), with a cross-reference to the Copilot tool-surface-limits section.
- **`mcp_setup_m365_copilot.rst`** — replaces the stale manual workaround ("scope down" / "contact your rep for a split MCP server") with the automatic curation behavior. Retains the optional manual-restriction path.
- **`mcp_tool_reference.rst`** — since external is now the default, the reference now lists the full external surface. Adds the external tools that were missing (8 journey tools — versions, run, schedule/unschedule, node schema — plus a Deep links section for `build_object_url`) and removes `sandbox_list`, which is not a real tool (absent from the registry and `tools/list`).
- **`mcp_setup_chatgpt.rst`, `mcp_setup_claude.rst`, `mcp_setup_m365_copilot.rst`** — render the OAuth client ID as a copyable code-block (copy button via sphinx-copybutton) instead of bold text, so users can paste the long opaque string exactly.

## Test plan

- [x] Built the API section locally with the command CI runs (`sphinx-build -b html --jobs auto -W amperity_api/source`) — build succeeded, 0 warnings/errors.
- [x] Verified the `mcp_overview` `:ref:` resolves to `mcp_setup_m365_copilot.html#mcp-setup-copilot-surface-limits`.
- [x] Cross-checked the tool reference against `EXTERNAL_TOOLS` in amperity-mcp: every external tool is documented; no phantom entries remain.
- [x] Confirmed the client ID renders as a highlight block on all three setup pages (including inside the Copilot field-table cell), so copybutton attaches a copy button.

[AI-1970]: https://amperity.atlassian.net/browse/AI-1970

🤖 Generated with [Claude Code](https://claude.com/claude-code)
