### PR TITLE
AI-2034 Add Gemini CLI MCP setup docs

### DIFF
--- a/amperity_api/source/index.rst
+++ b/amperity_api/source/index.rst
@@ -93,6 +93,7 @@ Amperity has an `OpenAPI specification <https://docs.amperity.com/api/openapi.ht
    Set up ChatGPT <mcp_setup_chatgpt>
    Set up Claude <mcp_setup_claude>
    Set up Copilot Studio <mcp_setup_m365_copilot>
+   Set up Gemini CLI <mcp_setup_gemini>
    Safety modes <mcp_safety_modes>
    Tools reference <mcp_tool_reference>
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -104,5 +104,6 @@ Connect a client to the MCP server:
 * :doc:`ChatGPT custom connectors <mcp_setup_chatgpt>`
 * :doc:`Claude.ai, Claude Desktop, and Claude Code <mcp_setup_claude>`
 * :doc:`Copilot Studio <mcp_setup_m365_copilot>`
+* :doc:`Gemini CLI <mcp_setup_gemini>`
 
 .. mcp-connect-client-end

--- a/amperity_api/source/mcp_setup_chatgpt.rst
+++ b/amperity_api/source/mcp_setup_chatgpt.rst
@@ -36,7 +36,6 @@ Connecting ChatGPT to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
 * Access to ChatGPT with a plan that supports custom MCP connectors.
-* The :ref:`URL for your tenant's MCP server endpoint <mcp-overview-mcp-urls>`.
 
 .. mcp-setup-chatgpt-requirements-end
 

--- a/amperity_api/source/mcp_setup_claude.rst
+++ b/amperity_api/source/mcp_setup_claude.rst
@@ -36,7 +36,6 @@ Connecting Claude to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
 * Access to a Claude account--**Pro**, **Max**, **Team**, or **Enterprise**--or access to Claude Code.
-* The :ref:`URL for your tenant's MCP server endpoint <mcp-overview-mcp-urls>`.
 
 .. mcp-setup-claude-requirements-end
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -38,7 +38,6 @@ Connecting Gemini CLI to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
 * Gemini CLI installed and signed in.
-* The :ref:`URL for your tenant's MCP server endpoint <mcp-overview-mcp-urls>`.
 
 .. mcp-setup-gemini-requirements-end
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -64,8 +64,7 @@ Register the Amperity MCP server in your Gemini CLI configuration.
       {
         "mcpServers": {
           "amperity": {
-            "url": "https://mcp.amperity.com",
-            "type": "http",
+            "httpUrl": "https://mcp.amperity.com",
             "oauth": {
               "clientId": "nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs",
               "authorizationUrl": "https://mcp.amperity.com/authorize",

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -20,7 +20,7 @@ Set up Gemini CLI
 
 .. mcp-setup-gemini-start
 
-Connect Gemini CLI to the Amperity MCP server by registering it as a remote HTTP server and configuring OAuth with Amperity's static client ID.
+Connect Gemini CLI to the Amperity MCP server by adding it as a remote MCP server and signing in with your Amperity credentials.
 
 .. important:: Gemini CLI only works for organizations on a Gemini Code Assist Standard or Enterprise license.
 
@@ -57,8 +57,6 @@ Register the Amperity MCP server in your Gemini CLI configuration.
    .. code-block:: bash
 
       gemini mcp add --transport http --scope user amperity https://mcp.amperity.com
-
-   The ``--scope user`` flag registers the server in your user-scoped configuration (``~/.gemini/settings.json``) so it is available in every Gemini CLI session. Use ``--scope project`` to register it for a single project instead (``.gemini/settings.json``).
 
 #. Add Amperity's OAuth client ID to the server entry. Open ``~/.gemini/settings.json`` and add an ``oauth`` block to the ``amperity`` server so it matches the following:
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -1,0 +1,137 @@
+.. https://docs.amperity.com/api/
+
+
+.. meta::
+    :description lang=en:
+        Configure Gemini CLI to connect to the Amperity MCP server.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Gemini CLI to connect to the Amperity MCP server.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Set up Gemini CLI
+
+
+==================================================
+Set up Gemini CLI
+==================================================
+
+.. mcp-setup-gemini-start
+
+Connect Gemini CLI to the Amperity MCP server by registering it as a remote HTTP server and configuring OAuth with Amperity's static client ID.
+
+.. important:: Gemini CLI only works for organizations on a Gemini Code Assist Standard or Enterprise license.
+
+.. mcp-setup-gemini-end
+
+
+.. _mcp-setup-gemini-requirements:
+
+Requirements
+==================================================
+
+.. mcp-setup-gemini-requirements-start
+
+Connecting Gemini CLI to the MCP server requires:
+
+* An active Amperity account with access to at least one tenant.
+* Gemini CLI installed and signed in.
+* The :ref:`URL for your tenant's MCP server endpoint <mcp-overview-mcp-urls>`.
+
+.. mcp-setup-gemini-requirements-end
+
+
+.. _mcp-setup-gemini-add:
+
+Add the Amperity MCP server
+==================================================
+
+.. mcp-setup-gemini-add-start
+
+Register the Amperity MCP server in your Gemini CLI configuration.
+
+#. Add the server:
+
+   .. code-block:: bash
+
+      gemini mcp add --transport http --scope user amperity https://mcp.amperity.com
+
+   The ``--scope user`` flag registers the server in your user-scoped configuration (``~/.gemini/settings.json``) so it is available in every Gemini CLI session. Use ``--scope project`` to register it for a single project instead (``.gemini/settings.json``).
+
+#. Add Amperity's OAuth client ID to the server entry. Open ``~/.gemini/settings.json`` and add an ``oauth`` block to the ``amperity`` server so it matches the following:
+
+   .. code-block:: json
+
+      {
+        "mcpServers": {
+          "amperity": {
+            "url": "https://mcp.amperity.com",
+            "type": "http",
+            "oauth": {
+              "clientId": "nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs",
+              "authorizationUrl": "https://mcp.amperity.com/authorize",
+              "tokenUrl": "https://mcp.amperity.com/oauth/token"
+            }
+          }
+        }
+      }
+
+   .. important:: The ``oauth.clientId`` field is required. By default Gemini CLI attempts dynamic client registration, which the Amperity MCP server rejects with ``dynamic client registration is disabled``. Providing the static client ID tells Gemini CLI to use Amperity's pre-registered public client instead. Amperity uses PKCE, so no client secret is needed.
+
+.. mcp-setup-gemini-add-end
+
+
+.. _mcp-setup-gemini-authenticate:
+
+Authenticate
+==================================================
+
+.. mcp-setup-gemini-authenticate-start
+
+Complete the OAuth flow to connect to the MCP server.
+
+#. Start Gemini CLI, or restart it if it was already running, so it reloads ``settings.json``:
+
+   .. code-block:: bash
+
+      gemini
+
+#. Trigger the OAuth flow:
+
+   .. code-block:: none
+
+      /mcp auth amperity
+
+   A browser tab opens. Sign in with your Amperity OAuth credentials. Gemini CLI reports a successful authentication and reloads the Amperity tools.
+
+#. Verify the server is connected:
+
+   .. code-block:: none
+
+      /mcp
+
+   The **amperity** server appears with its available tools.
+
+.. mcp-setup-gemini-authenticate-end
+
+
+.. _mcp-setup-gemini-interacting:
+
+Start interacting with Gemini CLI
+==================================================
+
+.. mcp-setup-gemini-interacting-start
+
+In a Gemini CLI session, ask:
+
+.. code-block:: none
+
+   "Tell me about my Amperity tenant."
+
+Gemini CLI calls the **tenant_info** tool and returns details about your current Amperity tenant.
+
+.. tip:: If you see a ``dynamic client registration is disabled`` error during ``/mcp auth``, confirm the ``oauth.clientId`` field is present in your ``amperity`` server entry in ``settings.json``, and then restart Gemini CLI to reload the configuration.
+
+.. mcp-setup-gemini-interacting-end

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -76,7 +76,7 @@ Register the Amperity MCP server in your Gemini CLI configuration.
         }
       }
 
-   .. important:: The ``oauth.clientId`` field is required. By default Gemini CLI attempts dynamic client registration, which the Amperity MCP server rejects with ``dynamic client registration is disabled``. Providing the static client ID tells Gemini CLI to use Amperity's pre-registered public client instead. Amperity uses PKCE, so no client secret is needed.
+   .. important:: The ``oauth.clientId`` field is required. Without it, Gemini CLI cannot authenticate to the Amperity MCP server.
 
 .. mcp-setup-gemini-add-end
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -88,8 +88,6 @@ Authenticate
 
 .. mcp-setup-gemini-authenticate-start
 
-Complete the OAuth flow to connect to the MCP server.
-
 #. Start Gemini CLI, or restart it if it was already running, so it reloads ``settings.json``:
 
    .. code-block:: bash
@@ -129,7 +127,5 @@ In a Gemini CLI session, ask:
    "Tell me about my Amperity tenant."
 
 Gemini CLI calls the **tenant_info** tool and returns details about your current Amperity tenant.
-
-.. tip:: If you see a ``dynamic client registration is disabled`` error during ``/mcp auth``, confirm the ``oauth.clientId`` field is present in your ``amperity`` server entry in ``settings.json``, and then restart Gemini CLI to reload the configuration.
 
 .. mcp-setup-gemini-interacting-end

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -36,7 +36,6 @@ Connecting Copilot Studio to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
 * Access to Copilot Studio with permission to add custom connectors.
-* The :ref:`URL for your tenant's MCP server endpoint <mcp-overview-mcp-urls>`.
 
 .. mcp-setup-copilot-requirements-end
 


### PR DESCRIPTION
Adding gemini CLI setup page. 

Also removing a crufty note from when there were stack-specific MCP URLs.