### PR TITLE
AI-2118: MCP docs — remove tenant_use, document per-call tenant_id

### DIFF
--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -79,7 +79,7 @@ The Amperity MCP server does not:
 
   .. important:: A user of the Amperity MCP server sees only the tenants and operations allowed by their credentials.
 
-* Store conversation history. Per-token session state--selected tenant and safety mode--persists across requests within the same session.
+* Store conversation history. The safety mode is the only per-token state that persists across requests within the same session. Tenant context never persists--every tenant-scoped tool call names its tenant with a **tenant_id** argument.
 
 * Control the AI client or its underlying model.
 

--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -32,7 +32,7 @@ For the canonical list available to your account, send a **tools/list** request 
 Tenants and sessions
 ==================================================
 
-Manage which Amperity tenant the current session targets, and read session-level safety configuration.
+Discover the tenants available to your account, and read session-level safety configuration. Every tenant-scoped tool takes a **tenant_id** argument -- an id from **tenant_list**, optionally stack-qualified as **stack:tenant_id** -- so each call names the tenant it runs against. There is no session-selected tenant to switch.
 
 .. list-table::
    :header-rows: 1
@@ -41,12 +41,10 @@ Manage which Amperity tenant the current session targets, and read session-level
    * - Description
      - Tools
 
-   * - List, inspect, switch, and refresh tenants
+   * - List, inspect, and refresh tenants
      - **tenant_list**
 
        **tenant_info**
-
-       **tenant_use**
 
        **tenant_resync**
 


### PR DESCRIPTION
**Customer impact:** Public docs at docs.amperity.com stop describing the removed `tenant_use` tool and the session-tenant model — keeps published behavior in sync with [amperity-mcp#590].

## Summary
Companion docs sync for the AI-2109 per-call tenant cutover ([amperity-mcp#590]): `tenant_use` is removed from the MCP tool surface and every tenant-scoped tool now takes a per-call `tenant_id` (optionally `stack:tenant_id`-qualified).

## Changes
- `mcp_tool_reference.rst` — tenant group intro now explains the per-call `tenant_id` argument ("no session-selected tenant to switch"); drops the `tenant_use` table entry and the "switch" wording.
- `mcp_overview.rst` — the session-state bullet now scopes per-token persistence to the safety mode only; tenant context never persists.

## Testing
Wording-only `.rst` edits; table structure unchanged (eyeballed — no local Sphinx toolchain to build with).

## Sequencing
Merge/publish around when [amperity-mcp#590] deploys, so docs match the live tool surface. Not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[amperity-mcp#590]: https://github.com/amperity/amperity-mcp/pull/590
[AI-2118]: https://amperity.atlassian.net/browse/AI-2118
[AI-2109]: https://amperity.atlassian.net/browse/AI-2109
