### PR TITLE
Add troubleshooting notes to Claude and ChatGPT MCP setup pages

### DIFF
--- a/amperity_api/source/mcp_setup_chatgpt.rst
+++ b/amperity_api/source/mcp_setup_chatgpt.rst
@@ -88,4 +88,6 @@ ChatGPT calls the **tenant_info** tool and return details about your current Amp
 
 .. note:: Write operations in ChatGPT require a manual-confirm prompt in the chat the first time they are called.
 
+.. note:: ChatGPT snapshots the tool list when an MCP connector is published. If you are unable to access tools documented in the :doc:`tool reference </mcp_tool_reference>`, the connector may need to be updated. Contact your workplace administrator to review and publish an updated version of the connector.
+
 .. mcp-setup-chatgpt-interacting-end

--- a/amperity_api/source/mcp_setup_claude.rst
+++ b/amperity_api/source/mcp_setup_claude.rst
@@ -130,4 +130,6 @@ Claude calls the **tenant_info** tool and return details about your current Ampe
 
       claude mcp add --transport http --scope user amperity https://mcp.amperity.com
 
+.. tip:: If Claude is unable to start a session, the ``session_start`` tool may need to be explicitly allowed. In Claude.ai, open **Customize** > **Connectors**, select the Amperity connector, find ``session_start`` in the tool list, and set it to **Always allow**.
+
 .. mcp-setup-claude-interacting-end


### PR DESCRIPTION
## Summary

- **Claude setup**: adds a tip that if Claude can't start a session, users may need to set `session_start` to Always allow in Customize > Connectors
- **ChatGPT setup**: adds a note that the tool list is snapshotted at publish time; users missing tools should ask their administrator to publish an update

## Test plan

- [x] Build `make api` and verify both pages render correctly
- [x] Check cross-reference link in ChatGPT page resolves to the tool reference