### PR TITLE
AI-2204: MCP Copilot Studio setup — use Dynamic discovery

### DIFF
--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -72,32 +72,11 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
       * - **Server URL**
         - **https://mcp.amperity.com**
 
-#. Under **Authentication**, select **OAuth 2.0**.
+#. Under **Authentication**, select **OAuth 2.0**, and then choose the **Dynamic discovery** type.
 
-   Choose the **Manual** type and fill in the following fields.
+   With **Dynamic discovery**, **Copilot Studio** reads the Amperity MCP server's discovery metadata and registers itself automatically, so there is no Client ID, client secret, or endpoint URL to enter. This path also negotiates PKCE, which the Amperity MCP server requires.
 
-   .. list-table::
-      :header-rows: 1
-      :widths: 30 70
-
-      * - Field
-        - Value
-      * - **Client ID**
-        - .. code-block:: none
-
-             nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs
-      * - **Client secret**
-        - Any non-empty placeholder, for example "unused". The Amperity MCP server is a PKCE-based public OAuth client and ignores this value, but **Copilot Studio** requires the field to be non-empty.
-      * - **Authorization URL**
-        - **https://mcp.amperity.com/authorize**
-      * - **Token URL template**
-        - **https://mcp.amperity.com/oauth/token**
-      * - **Refresh URL**
-        - **https://mcp.amperity.com/oauth/token**
-
-#. Select **Create**. **Copilot Studio** displays a callback URL. The Amperity OAuth proxy registers the callback URL dynamically.
-
-#. Select **Next** to continue. On the **Add tool** dialog, choose **Create a new connection** and sign in with your Amperity credentials.
+#. Select **Create**, and then **Next** to continue. On the **Add tool** dialog, choose **Create a new connection** and sign in with your Amperity credentials.
 #. Select **Add to agent**.
 
 .. mcp-setup-copilot-studio-steps-end

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -72,9 +72,7 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
       * - **Server URL**
         - **https://mcp.amperity.com**
 
-#. Under **Authentication**, select **OAuth 2.0**, and then choose the **Dynamic discovery** type.
-
-   With **Dynamic discovery**, **Copilot Studio** reads the Amperity MCP server's discovery metadata and registers itself automatically, so there is no Client ID, client secret, or endpoint URL to enter. This path also negotiates PKCE, which the Amperity MCP server requires.
+#. Under **Authentication**, select **OAuth 2.0**, and then choose the **Dynamic discovery** type. No Client ID, secret, or endpoint URLs are required.
 
 #. Select **Create**, and then **Next** to continue. On the **Add tool** dialog, choose **Create a new connection** and sign in with your Amperity credentials.
 #. Select **Add to agent**.

--- a/amperity_api/source/mcp_setup_m365_copilot.rst
+++ b/amperity_api/source/mcp_setup_m365_copilot.rst
@@ -72,7 +72,7 @@ Use the **Copilot Studio** MCP onboarding wizard to configure server details and
       * - **Server URL**
         - **https://mcp.amperity.com**
 
-#. Under **Authentication**, select **OAuth 2.0**, and then choose the **Dynamic discovery** type. No Client ID, secret, or endpoint URLs are required.
+#. Under **Authentication**, select **OAuth 2.0**, and then choose the **Dynamic discovery** type.
 
 #. Select **Create**, and then **Next** to continue. On the **Add tool** dialog, choose **Create a new connection** and sign in with your Amperity credentials.
 #. Select **Add to agent**.


### PR DESCRIPTION
**Customer impact:** Customers following the Copilot Studio MCP setup currently paste **Manual** OAuth fields, which ride a generic-OAuth connector that can't send PKCE — and the Amperity MCP `/authorize` proxy requires it, so the connection fails with `pkce_required`. Switching the docs to **Dynamic discovery** (Copilot reads the server's `.well-known` metadata, self-registers, and sends PKCE) means there's nothing to paste and the connection succeeds.

**Change:** the Authentication step now selects **OAuth 2.0 → Dynamic discovery**; the Client ID / secret / Authorization URL / Token URL table is removed.

Mirrors the `amperity-mcp` README change in amperity/amperity-mcp#630. Related: AI-2052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)