### PR TITLE
AI-2280 Split Gemini MCP setup into Antigravity and Gemini CLI

### DIFF
--- a/amperity_api/source/index.rst
+++ b/amperity_api/source/index.rst
@@ -93,7 +93,7 @@ Amperity has an `OpenAPI specification <https://docs.amperity.com/api/openapi.ht
    Set up ChatGPT <mcp_setup_chatgpt>
    Set up Claude <mcp_setup_claude>
    Set up Copilot Studio <mcp_setup_m365_copilot>
-   Set up Gemini CLI <mcp_setup_gemini>
+   Set up Gemini <mcp_setup_gemini>
    Safety modes <mcp_safety_modes>
    Tools reference <mcp_tool_reference>
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -104,6 +104,6 @@ Connect a client to the MCP server:
 * :doc:`ChatGPT custom connectors <mcp_setup_chatgpt>`
 * :doc:`Claude.ai, Claude Desktop, and Claude Code <mcp_setup_claude>`
 * :doc:`Copilot Studio <mcp_setup_m365_copilot>`
-* :doc:`Gemini CLI <mcp_setup_gemini>`
+* :doc:`Gemini -- Antigravity and Gemini CLI <mcp_setup_gemini>`
 
 .. mcp-connect-client-end

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -64,13 +64,7 @@ Add the Amperity MCP server
 
 Register the Amperity MCP server as a custom server in your Antigravity configuration.
 
-#. Open your Antigravity MCP configuration file. This is the global file at ``~/.gemini/config/mcp_config.json`` (applies to every workspace) or the workspace-local file at ``.agents/mcp_config.json`` (applies to the current project only).
-
-   You can edit this file directly, or open it from within Antigravity:
-
-   * **Antigravity IDE**: In the editor's agent side panel, click **...**, select **MCP Servers**, click **Manage MCP Servers**, then click **View raw config**.
-   * **Antigravity 2.0**: Click **Settings** at the bottom left, select **Customizations**, then edit the raw config under **Installed MCP Servers**.
-   * **Antigravity CLI**: Type ``/mcp`` in the prompt panel to open the MCP Manager, or edit the file directly.
+#. Open your global Antigravity MCP configuration file at ``~/.gemini/config/mcp_config.json``.
 
 #. Add the ``amperity`` server with Amperity's OAuth client ID:
 
@@ -98,8 +92,6 @@ Authenticate
 --------------------------------------------------
 
 .. mcp-setup-antigravity-authenticate-start
-
-#. Reload your MCP servers so Antigravity picks up the new configuration: click **...** at the top of the agent side panel, select **MCP Servers**, then refresh.
 
 #. Open **Agent Settings** with :kbd:`Cmd+,` (macOS) or :kbd:`Ctrl+,` (Windows/Linux) and go to the **Customizations** tab.
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -64,7 +64,13 @@ Add the Amperity MCP server
 
 Register the Amperity MCP server as a custom server in your Antigravity configuration.
 
-#. Open your Antigravity MCP configuration file. Use the global file at ``~/.gemini/config/mcp_config.json``, or the workspace-local file at ``.agents/mcp_config.json``. You can also open it from the app: click **...** at the top of the agent side panel, select **MCP Servers**, click **Manage MCP Servers**, then **View raw config**.
+#. Open your Antigravity MCP configuration file. This is the global file at ``~/.gemini/config/mcp_config.json`` (applies to every workspace) or the workspace-local file at ``.agents/mcp_config.json`` (applies to the current project only).
+
+   You can edit this file directly, or open it from within Antigravity:
+
+   * **Antigravity IDE**: In the editor's agent side panel, click **...**, select **MCP Servers**, click **Manage MCP Servers**, then click **View raw config**.
+   * **Antigravity 2.0**: Click **Settings** at the bottom left, select **Customizations**, then edit the raw config under **Installed MCP Servers**.
+   * **Antigravity CLI**: Type ``/mcp`` in the prompt panel to open the MCP Manager, or edit the file directly.
 
 #. Add the ``amperity`` server with Amperity's OAuth client ID:
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -93,7 +93,9 @@ Authenticate
 
 .. mcp-setup-antigravity-authenticate-start
 
-#. Click **Authenticate** next to the **amperity** server. A browser tab opens. Sign in with your Amperity OAuth credentials and select your tenant.
+#. Click **Settings** at the bottom left, then select the **Customizations** tab.
+
+#. Under **Installed MCP Servers**, click **Authenticate** next to the **amperity** server. A browser tab opens. Sign in with your Amperity OAuth credentials and select your tenant.
 
 #. Copy the authorization code from the browser, paste it back into the settings panel, and click **Submit**. The server reconnects automatically and its tools become available.
 

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -3,51 +3,160 @@
 
 .. meta::
     :description lang=en:
-        Configure Gemini CLI to connect to the Amperity MCP server.
+        Configure Antigravity or Gemini CLI to connect to the Amperity MCP server.
 
 .. meta::
     :content class=swiftype name=body data-type=text:
-        Configure Gemini CLI to connect to the Amperity MCP server.
+        Configure Antigravity or Gemini CLI to connect to the Amperity MCP server.
 
 .. meta::
     :content class=swiftype name=title data-type=string:
-        Set up Gemini CLI
+        Set up Gemini
 
 
 ==================================================
-Set up Gemini CLI
+Set up Gemini
 ==================================================
 
 .. mcp-setup-gemini-start
+
+Connect Google's Gemini agents to the Amperity MCP server and sign in with your Amperity credentials. This page covers two clients:
+
+* :ref:`Antigravity <mcp-setup-antigravity>` -- Google's agentic IDE.
+* :ref:`Gemini CLI <mcp-setup-gemini-cli>` -- the command-line agent.
+
+.. mcp-setup-gemini-end
+
+
+.. _mcp-setup-antigravity:
+
+Antigravity
+==================================================
+
+.. mcp-setup-antigravity-start
+
+Connect Antigravity to the Amperity MCP server by adding it as a custom remote MCP server and signing in with your Amperity credentials.
+
+.. mcp-setup-antigravity-end
+
+
+.. _mcp-setup-antigravity-requirements:
+
+Requirements
+--------------------------------------------------
+
+.. mcp-setup-antigravity-requirements-start
+
+Connecting Antigravity to the MCP server requires:
+
+* An active Amperity account with access to at least one tenant.
+* Antigravity installed and signed in.
+
+.. mcp-setup-antigravity-requirements-end
+
+
+.. _mcp-setup-antigravity-add:
+
+Add the Amperity MCP server
+--------------------------------------------------
+
+.. mcp-setup-antigravity-add-start
+
+Register the Amperity MCP server as a custom server in your Antigravity configuration.
+
+#. Open your Antigravity MCP configuration file. Use the global file at ``~/.gemini/config/mcp_config.json``, or the workspace-local file at ``.agents/mcp_config.json``. You can also open it from the app: click **...** at the top of the agent side panel, select **MCP Servers**, click **Manage MCP Servers**, then **View raw config**.
+
+#. Add the ``amperity`` server with Amperity's OAuth client ID:
+
+   .. code-block:: json
+
+      {
+        "mcpServers": {
+          "amperity": {
+            "serverUrl": "https://mcp.amperity.com",
+            "oauth": {
+              "clientId": "nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs"
+            }
+          }
+        }
+      }
+
+   .. important:: Antigravity requires the ``serverUrl`` field for remote servers; the ``url`` and ``httpUrl`` fields are not supported. The ``oauth.clientId`` field is required so Antigravity surfaces the **Authenticate** button.
+
+.. mcp-setup-antigravity-add-end
+
+
+.. _mcp-setup-antigravity-authenticate:
+
+Authenticate
+--------------------------------------------------
+
+.. mcp-setup-antigravity-authenticate-start
+
+#. Reload your MCP servers so Antigravity picks up the new configuration: click **...** at the top of the agent side panel, select **MCP Servers**, then refresh.
+
+#. Open **Agent Settings** with :kbd:`Cmd+,` (macOS) or :kbd:`Ctrl+,` (Windows/Linux) and go to the **Customizations** tab.
+
+#. Click **Authenticate** next to the **amperity** server. A browser tab opens. Sign in with your Amperity OAuth credentials and select your tenant.
+
+#. Copy the authorization code from the browser, paste it back into the settings panel, and click **Submit**. The server reconnects automatically and its tools become available.
+
+.. mcp-setup-antigravity-authenticate-end
+
+
+.. _mcp-setup-antigravity-interacting:
+
+Start interacting with Antigravity
+--------------------------------------------------
+
+.. mcp-setup-antigravity-interacting-start
+
+In an Antigravity agent session, ask:
+
+.. code-block:: none
+
+   "Tell me about my Amperity tenant."
+
+Antigravity calls the **tenant_info** tool and returns details about your current Amperity tenant.
+
+.. mcp-setup-antigravity-interacting-end
+
+
+.. _mcp-setup-gemini-cli:
+
+Gemini CLI
+==================================================
+
+.. mcp-setup-gemini-cli-start
 
 Connect Gemini CLI to the Amperity MCP server by adding it as a remote MCP server and signing in with your Amperity credentials.
 
 .. important:: Gemini CLI only works for organizations on a Gemini Code Assist Standard or Enterprise license.
 
-.. mcp-setup-gemini-end
+.. mcp-setup-gemini-cli-end
 
 
-.. _mcp-setup-gemini-requirements:
+.. _mcp-setup-gemini-cli-requirements:
 
 Requirements
-==================================================
+--------------------------------------------------
 
-.. mcp-setup-gemini-requirements-start
+.. mcp-setup-gemini-cli-requirements-start
 
 Connecting Gemini CLI to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
 * Gemini CLI installed and signed in.
 
-.. mcp-setup-gemini-requirements-end
+.. mcp-setup-gemini-cli-requirements-end
 
 
-.. _mcp-setup-gemini-add:
+.. _mcp-setup-gemini-cli-add:
 
 Add the Amperity MCP server
-==================================================
+--------------------------------------------------
 
-.. mcp-setup-gemini-add-start
+.. mcp-setup-gemini-cli-add-start
 
 Register the Amperity MCP server in your Gemini CLI configuration.
 
@@ -76,15 +185,15 @@ Register the Amperity MCP server in your Gemini CLI configuration.
 
    .. important:: The ``oauth.clientId`` field is required. Without it, Gemini CLI cannot authenticate to the Amperity MCP server.
 
-.. mcp-setup-gemini-add-end
+.. mcp-setup-gemini-cli-add-end
 
 
-.. _mcp-setup-gemini-authenticate:
+.. _mcp-setup-gemini-cli-authenticate:
 
 Authenticate
-==================================================
+--------------------------------------------------
 
-.. mcp-setup-gemini-authenticate-start
+.. mcp-setup-gemini-cli-authenticate-start
 
 #. Start Gemini CLI, or restart it if it was already running, so it reloads ``settings.json``:
 
@@ -108,15 +217,15 @@ Authenticate
 
    The **amperity** server appears with its available tools.
 
-.. mcp-setup-gemini-authenticate-end
+.. mcp-setup-gemini-cli-authenticate-end
 
 
-.. _mcp-setup-gemini-interacting:
+.. _mcp-setup-gemini-cli-interacting:
 
 Start interacting with Gemini CLI
-==================================================
+--------------------------------------------------
 
-.. mcp-setup-gemini-interacting-start
+.. mcp-setup-gemini-cli-interacting-start
 
 In a Gemini CLI session, ask:
 
@@ -126,4 +235,4 @@ In a Gemini CLI session, ask:
 
 Gemini CLI calls the **tenant_info** tool and returns details about your current Amperity tenant.
 
-.. mcp-setup-gemini-interacting-end
+.. mcp-setup-gemini-cli-interacting-end

--- a/amperity_api/source/mcp_setup_gemini.rst
+++ b/amperity_api/source/mcp_setup_gemini.rst
@@ -93,8 +93,6 @@ Authenticate
 
 .. mcp-setup-antigravity-authenticate-start
 
-#. Open **Agent Settings** with :kbd:`Cmd+,` (macOS) or :kbd:`Ctrl+,` (Windows/Linux) and go to the **Customizations** tab.
-
 #. Click **Authenticate** next to the **amperity** server. A browser tab opens. Sign in with your Amperity OAuth credentials and select your tenant.
 
 #. Copy the authorization code from the browser, paste it back into the settings panel, and click **Submit**. The server reconnects automatically and its tools become available.


### PR DESCRIPTION
## 👨 Summary
Gemini CLI is mostly deprecated (though still available to enterprise customers). Antigravity is the new tool. It's also... pretty incomplete?
I've managed to connect our MCP up in it, and added the working steps to our Gemini setup docs. Mayhaps in future doing so won't require manual updates to ~/.gemini/config/mcp_config.json. 

## 🤖 Summary

Splits the Gemini MCP setup page into two client sections and documents Antigravity support (paired with the server-side redirect-URI fix in amperity-mcp#675).

- Renames the page from **Set up Gemini CLI** to **Set up Gemini**.
- Adds an **Antigravity** section at the top: custom-server config in `~/.gemini/config/mcp_config.json` (`serverUrl` + `oauth.clientId`) and the browser Authenticate flow (Agent Settings → Customizations → Authenticate → paste code).
- Keeps the existing **Gemini CLI** steps below, unchanged.
- Updates the toctree label (`Set up Gemini`) and the overview page link.

## Why

Antigravity uses a hosted callback (`https://antigravity.google/oauth-callback`) that the MCP server now allowlists. Its config also differs from Gemini CLI: it requires `serverUrl` (not `httpUrl`) and authenticates through the IDE's Authenticate button rather than `/mcp auth`.

## Related

- amperity-mcp#675 (server allowlist change)
- Jira: AI-2280
