### PR TITLE
Add CDT alias to custom domain table glossary entry

### DIFF
--- a/amperity_reference/source/glossary.rst
+++ b/amperity_reference/source/glossary.rst
@@ -1190,7 +1190,7 @@ C
 
 .. _c-custom-domain-table:
 
-**custom domain table**
+**custom domain table**, **CDT**
    .. include:: ../../shared/terms.rst
       :start-after: .. term-custom-domain-table-start
       :end-before: .. term-custom-domain-table-end


### PR DESCRIPTION
## Summary
- Adds "CDT" as an alias to the existing "custom domain table" glossary entry so site search for "CDT" returns a result.

## Test plan
- [ ] Build docs site and search "CDT" to confirm it now resolves to the glossary entry.