### PR TITLE
Remove MCP private beta references for GA

### DIFF
--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -27,11 +27,6 @@ The MCP server is hosted by Amperity. Customers connect to a single public endpo
 .. mcp-overview-end
 
 
-.. admonition:: Private beta
-
-   The MCP server is available as a private beta. Tool surface, configuration, and behavior may change as the beta progresses. Tool count is approximate during beta and subject to change. Contact your Amperity representative for access.
-
-
 .. _mcp-overview-mcp-urls:
 
 MCP server URL

--- a/amperity_api/source/mcp_safety_modes.rst
+++ b/amperity_api/source/mcp_safety_modes.rst
@@ -28,7 +28,7 @@ The Amperity MCP server gates write operations behind a per-session safety mode.
 
 .. note::
 
-   The safety mode model may change as Amperity moves toward more granular access controls. The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. Pair safety mode with the access controls on the underlying Amperity tenant.
+   The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. Pair safety mode with the access controls on the underlying Amperity tenant.
 
 
 

--- a/amperity_api/source/mcp_safety_modes.rst
+++ b/amperity_api/source/mcp_safety_modes.rst
@@ -28,7 +28,7 @@ The Amperity MCP server gates write operations behind a per-session safety mode.
 
 .. note::
 
-   The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. The true permission boundary is the tool permissions configured in your MCP client (for example, Claude's per-tool "Always allow," "Needs approval," and "Blocked" settings).
+   The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. The true permission boundary is the tool permissions configured in your MCP client.
 
 
 

--- a/amperity_api/source/mcp_safety_modes.rst
+++ b/amperity_api/source/mcp_safety_modes.rst
@@ -28,7 +28,7 @@ The Amperity MCP server gates write operations behind a per-session safety mode.
 
 .. note::
 
-   The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. Pair safety mode with the access controls on the underlying Amperity tenant.
+   The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. The true permission boundary is the tool permissions configured in your MCP client (for example, Claude's per-tool "Always allow," "Needs approval," and "Blocked" settings).
 
 
 

--- a/amperity_api/source/mcp_safety_modes.rst
+++ b/amperity_api/source/mcp_safety_modes.rst
@@ -28,7 +28,7 @@ The Amperity MCP server gates write operations behind a per-session safety mode.
 
 .. note::
 
-   The safety mode model may change during beta as Amperity moves toward more granular access controls. The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. Pair safety mode with the access controls on the underlying Amperity tenant.
+   The safety mode model may change as Amperity moves toward more granular access controls. The agent can call the **safety_set_mode** tool to change the current session's mode. Treat the safety mode as a guardrail and not as a permission boundary. Pair safety mode with the access controls on the underlying Amperity tenant.
 
 
 


### PR DESCRIPTION
## Summary
- MCP is GA today — removes the "Private beta" admonition from mcp_overview.rst and drops the stale "during beta" wording in mcp_safety_modes.rst.

## Test plan
- [x] `make api` builds cleanly with no warnings
- [x] Verified rendered mcp_overview.html and mcp_safety_modes.html no longer contain "beta"/"preview" language