### PR TITLE
Fix remaining outdated EPM setup references missed by #862

### DIFF
--- a/amperity_operator/source/model_event_propensity.rst
+++ b/amperity_operator/source/model_event_propensity.rst
@@ -48,8 +48,8 @@ Recommended audience sizes
 --------------------------------------------------
 
 .. include:: ../../shared/terms.rst
-   :start-after: .. term-recommended-audience-size-start
-   :end-before: .. term-recommended-audience-size-end
+   :start-after: .. term-recommended-audience-size-events-start
+   :end-before: .. term-recommended-audience-size-events-end
 
 .. include:: ../../amperity_reference/source/model_event_propensity.rst
    :start-after: .. model-event-propensity-use-cases-recommended-audiences-about-start
@@ -231,9 +231,9 @@ When you add an event propensity model you first choose a model type. The four p
 
 .. model-event-propensity-configure-output-start
 
-After a model version passes evaluation, activate and schedule the model to begin generating predictions. See :ref:`predictive model how-tos <models-howtos>` for the steps to activate, schedule, and run a model.
+After a model version passes evaluation, activate the model to begin generating predictions. See :ref:`predictive model how-tos <models-howtos>` for the steps to activate a model.
 
-An active model produces a **Predicted Propensity** table named ``Predicted_Propensity_{EventName}``, where ``{EventName}`` is generated based the target event name provided during model creation. The fields in this table are :ref:`available in segments <model-event-propensity-segments>`.
+An active model produces a **Predicted Propensity** table named ``Predicted_Propensity_{EventName}``, where ``{EventName}`` is generated based on the target event name provided during model creation. The fields in this table are :ref:`available in segments <model-event-propensity-segments>`.
 
 .. model-event-propensity-configure-output-end
 

--- a/amperity_operator/source/model_event_propensity.rst
+++ b/amperity_operator/source/model_event_propensity.rst
@@ -325,7 +325,7 @@ Predicts the likelihood that a customer makes a repeat booking or purchase.
 * **Model type:** Repeat bookings (preset)
 * **Prediction audience:** Repeat event
 
-Use a target event table with one row per booking. Because this is a revenue-generating event, add a revenue field:
+Use a target event table with one row per booking. Because bookings generate revenue, add a revenue field:
 
 .. list-table:: ``Hotel_Bookings`` (target event)
    :widths: 18 18 18 18 18

--- a/amperity_operator/source/table_event_propensity.rst
+++ b/amperity_operator/source/table_event_propensity.rst
@@ -3,11 +3,11 @@
 
 .. meta::
     :description lang=en:
-        Configure and manage the Event Propensity table.
+        Learn about the Event Propensity table produced by an event propensity model.
 
 .. meta::
     :content class=swiftype name=body data-type=text:
-        Configure and manage the Event Propensity table.
+        Learn about the Event Propensity table produced by an event propensity model.
 
 .. meta::
     :content class=swiftype name=title data-type=string:
@@ -27,59 +27,24 @@ Event Propensity table
 
 .. table-event-propensity-note-end
 
-.. include:: ../../shared/terms.rst
-   :start-after: .. term-unified-product-catalog-table-with-ampiq-start
-   :end-before: .. term-unified-product-catalog-table-with-ampiq-end
-
 
 .. _table-event-propensity-add-table:
 
-Add the Event Propensity table
+How the Event Propensity table is created
 ==================================================
-
-.. include:: ../../shared/terms.rst
-   :start-after: .. term-event-propensity-table-start
-   :end-before: .. term-event-propensity-table-end
 
 .. table-event-propensity-add-table-about-start
 
-To add a **Event Propensity** table you must extend the customer 360 database to add a table that joins the **Event Propensity ProductAttribute** passthrough table to the **Event Propensity Audience ProductAttribute** passthrough table.
+Amperity creates the **Event Propensity** table automatically when you build and activate an event propensity model. You do not need to add the table by hand or write any SQL.
+
+Each active event propensity model produces its own output table, named ``Predicted_Propensity_{EventName}`` after the target event name provided during model setup. The table contains one row per customer per event, along with the customer's score, ranking, and recommended audience-size flags. See the :ref:`column reference <table-event-propensity-reference>` for details.
 
 .. table-event-propensity-add-table-about-end
 
-**To add the Event Propensity table**
+To start producing an **Event Propensity** table, build an event propensity model and then activate it:
 
-.. table-event-propensity-add-table-steps-start
-
-#. From the **Customer 360** page, select the **Databases** tab, select the menu for the customer 360 database, and then click **Edit**.
-#. From the **Database Editor**, click **Add Table**.
-#. Name the table "Event Propensity" or some other name that identifies this table as the event propensity table for your tenant.
-#. Set the build mode to **SQL**.
-#. Add the following SQL:
-
-   .. code-block:: sql
-      :linenos:
-
-      SELECT 
-        r.product_attribute AS `target_event_name`
-        ,r.amperity_id
-        ,r.score
-        ,r.ranking
-        ,r.ranking <= s.audience_size_small AS audience_size_small
-        ,r.ranking <= s.audience_size_medium AS audience_size_medium
-        ,r.ranking <= s.audience_size_large AS audience_size_large
-      FROM Predicted_Affinity_ProductAttribute AS r
-      LEFT JOIN Predicted_Affinity_Audience_ProductAttribute AS s
-      ON r.product_attribute = s.product_attribute
-
-#. Click **Validate** to verify the SQL runs without error.
-#. Click **Next**. This opens the **Database Table Definition** page.
-#. Add a table description. This enables a tooltip that is visible from other areas in Amperity.
-#. Verify that the **db/required** and **db/unique** database field semantics were applied to the **amperity_id** column.
-#. Under **Version History**, select **Enable table version history**.
-#. Click **Save**.
-
-.. table-event-propensity-add-table-steps-end
+* :ref:`Build an event propensity model <model-event-propensity-configure>`
+* :ref:`Predictive model how-tos <models-howtos>` for the steps to activate a model.
 
 
 .. _table-event-propensity-reference:

--- a/amperity_reference/source/data_tables.rst
+++ b/amperity_reference/source/data_tables.rst
@@ -1397,23 +1397,17 @@ The **Event Propensity** table has the following columns:
      - Boolean
      - A flag that indicates the recommended audience size. When this value is ``True`` the recommended audience size is large.
 
-       .. include:: ../../shared/terms.rst
-          :start-after: .. term-audience-size-large-start
-          :end-before: .. term-audience-size-large-end
+       A large audience is predicted to include ~90% of customers who are likely to perform the target event.
    * - **Audience Size Medium**
      - Boolean
      - A flag that indicates the recommended audience size. When this value is ``True`` the recommended audience size is medium.
 
-       .. include:: ../../shared/terms.rst
-          :start-after: .. term-audience-size-medium-start
-          :end-before: .. term-audience-size-medium-end
+       A medium audience is predicted to include ~70% of customers who are likely to perform the target event.
    * - **Audience Size Small**
      - Boolean
      - A flag that indicates the recommended audience size. When this value is ``True`` the recommended audience size is small.
 
-       .. include:: ../../shared/terms.rst
-          :start-after: .. term-audience-size-small-start
-          :end-before: .. term-audience-size-small-end
+       A small audience is predicted to include ~50% of customers who are likely to perform the target event.
 
        Use a small audience size to help prevent wasted spend and to reduce opt-outs.
 
@@ -1425,15 +1419,15 @@ The **Event Propensity** table has the following columns:
 
    * - **Score**
      - Float
-     - The strength of a customers's propensity for this event, shown as an uncalibrated probability.
+     - The strength of a customer's propensity for this event, shown as an uncalibrated probability between 0 and 1.
 
-       .. tip:: The score is used internally by Amperity, does not directly correlate to ranking or audience size, and should not be used in segments.
+       .. tip:: **Ranking** is derived directly from the score--customers are ranked in descending order of score--so a higher score corresponds to a higher ranking. Because the score is uncalibrated, target customers using **Ranking** and audience size rather than the raw score.
 
           Sort results by **Ranking**, and then compare those results to audience sizes. Higher rankings within smaller audience sizes correlate with higher propensity.
 
    * - **Target Event Name**
      - String
-     - The name of the target event used with a event propensity model.
+     - The name of the target event used with an event propensity model.
 
 .. data-tables-event-propensity-table-end
 

--- a/amperity_reference/source/model_event_propensity.rst
+++ b/amperity_reference/source/model_event_propensity.rst
@@ -53,12 +53,12 @@ Recommended audience sizes
 --------------------------------------------------
 
 .. include:: ../../shared/terms.rst
-   :start-after: .. term-recommended-audience-size-start
-   :end-before: .. term-recommended-audience-size-end
+   :start-after: .. term-recommended-audience-size-events-start
+   :end-before: .. term-recommended-audience-size-events-end
 
 .. model-event-propensity-use-cases-recommended-audiences-about-start
 
-Recommended audience sizes are calculated for 30-day window. An event curve is generated, along with corresponding audience sizes that show what size audience is required to capture 50%, 70%, and 90% of occurrences of a given target event during the previous 30 days.
+Recommended audience sizes are calculated for a 30-day window. An event curve is generated, along with corresponding audience sizes that show what size audience is required to capture 50%, 70%, and 90% of occurrences of a given target event during the previous 30 days.
 
 Audience sizes are inclusive of all smaller audience sizes.
 

--- a/amperity_user/source/model_event_propensity.rst
+++ b/amperity_user/source/model_event_propensity.rst
@@ -48,8 +48,8 @@ Recommended audience sizes
 --------------------------------------------------
 
 .. include:: ../../shared/terms.rst
-   :start-after: .. term-recommended-audience-size-start
-   :end-before: .. term-recommended-audience-size-end
+   :start-after: .. term-recommended-audience-size-events-start
+   :end-before: .. term-recommended-audience-size-events-end
 
 .. include:: ../../amperity_reference/source/model_event_propensity.rst
    :start-after: .. model-event-propensity-use-cases-recommended-audiences-about-start

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -2641,13 +2641,6 @@ Event propensity is a predictive model that finds the likelihood that a customer
 
 An **Event Propensity** table associates individual customers to the events that, depending on the event, are most likely to lead to engagement with your brand.
 
-.. term-event-propensity-table-end)
-
-
-.. term-event-propensity-table-start
-
-An **Event Propensity** table associates individual customers to the events that, depending on the event, are most likely to lead to engagement with your brand.
-
 .. term-event-propensity-table-end
 
 
@@ -5647,6 +5640,13 @@ A **Recommendation** table associates individual customers to a preferred catego
 A recommended audience is a feature of product affinity modeling that answers the following question: "Which audience size grows revenue over the next 30 days?" Product affinity modeling answers this question with small, medium, and large recommended audience sizes. A recommended audience predicts future purchasers over the next 30 days.
 
 .. term-recommended-audience-size-end
+
+
+.. term-recommended-audience-size-events-start
+
+A recommended audience is a feature of event propensity modeling that answers the following question: "Which audience size best captures the customers who are most likely to perform the target event over the next 30 days?" Event propensity modeling answers this question with small, medium, and large recommended audience sizes.
+
+.. term-recommended-audience-size-events-end
 
 
 **record count**


### PR DESCRIPTION
## Summary

Follow-up to #862. A coworker noted the docs still referenced the old event propensity model (EPM) setup UI after #862 merged. That PR rewrote the EPM *model* and *overview* pages but only touched those two files, so the obsolete manual-setup flow survived in the sibling topic pages, and several EPM sections were surfacing shared snippets that are worded for **product affinity / purchase** models.

This PR is intentionally **EPM-only**. (Churn propensity's setup page also appears to describe the old "Predictive enablement" / "Start validation" flow, but that's a separate model and out of scope here.)

## Changes

- **`table_event_propensity.rst`** — This page was cloned from the Product Affinity table page and told users to **manually build** the Event Propensity table with SQL that joins `Predicted_Affinity_*` passthrough tables. The model now auto-creates the table, so the manual "Add the Event Propensity table" section is replaced with a short "How the Event Propensity table is created" section (`Predicted_Propensity_{EventName}`, produced when you build and activate a model). Also removed a stray Unified Product Catalog / `pc/` note that never applied to EPM, and refreshed the meta description.

- **`data_tables.rst`** — Corrected the Event Propensity **Score** field: ranking is derived directly from the score, so the "does not directly correlate to ranking" claim is wrong. The steer to target on **Ranking** / audience size (rather than the raw, uncalibrated score) is kept. Also reworded the Event Propensity **Audience Size** columns from "future purchasers" to "customers who are likely to perform the target event." The Predicted Affinity table's equivalent wording is left untouched.

- **`shared/terms.rst`** — Added an event-worded `term-recommended-audience-size-events` variant (the shared `term-recommended-audience-size` is product-affinity-specific — "a feature of product affinity modeling… predicts future purchasers") and pointed the three EPM pages at it, following the existing `term-ranking-events` precedent. De-duplicated a malformed `event-propensity-table` term block.

- **`model_event_propensity.rst` (operator/reference/user)** — Point the "Recommended audience sizes" include at the new events variant.

- **Activate-only** — Corrected the output/how-tos wording: an EPM model only needs to be **activated** (not activated, scheduled, and run).

- **Grammar** — "generated based **on** the target event name," "calculated for **a** 30-day window," "used with **an** event propensity model."

## Validation

`make operator`, `make reference`, and `make user` all build clean with warnings-as-errors. Verified in the rendered HTML that the EPM pages no longer show product-affinity/"future purchasers" wording or the manual `Predicted_Affinity_*` SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)