### PR TITLE
AI-2327: Note the Claude.ai MCP tool-approval prompt

### DIFF
--- a/amperity_api/source/mcp_setup_claude.rst
+++ b/amperity_api/source/mcp_setup_claude.rst
@@ -130,6 +130,6 @@ Claude calls the **tenant_info** tool and return details about your current Ampe
 
       claude mcp add --transport http --scope user amperity https://mcp.amperity.com
 
-.. tip:: If Claude is unable to start a session, the ``session_start`` tool may need to be explicitly allowed. In Claude.ai, open **Customize** > **Connectors**, select the Amperity connector, find ``session_start`` in the tool list, and set it to **Always allow**.
+.. tip:: The first time Claude uses an Amperity tool, Claude.ai asks you to approve the tool call. To stop being prompted, open **Customize** > **Connectors**, select the Amperity connector, find the tool in the tool list, and set it to **Always allow**. For example, if Claude is unable to start a session, allow the ``session_start`` tool this way.
 
 .. mcp-setup-claude-interacting-end


### PR DESCRIPTION
**Customer impact:** Docs only — no product change. Clarifies why Claude prompts to approve each MCP tool and how to stop it, on the Claude setup page.

## Summary
Generalizes the existing `session_start` tip into a general statement: the first time Claude uses an Amperity tool, Claude.ai asks you to approve it; set the tool to **Always allow** in the connector settings (**Customize > Connectors**) to stop the prompt. Keeps `session_start` as the concrete example.

One-line change — no separate note, so it doesn't duplicate the mechanism already documented. Prompted by a support question from Jean; Stu suggested documenting it. Behavioral wording, no screenshots (Anthropic's connector UI changes).

## Testing
`make api` builds clean under `-W` (warnings-as-errors).

[AI-2327]: https://amperity.atlassian.net/browse/AI-2327
