### PR TITLE
Update bridge_snowflake.rst with new Snowflake account

### DIFF
--- a/amperity_operator/source/bridge_snowflake.rst
+++ b/amperity_operator/source/bridge_snowflake.rst
@@ -512,6 +512,10 @@ Snowflake must be configured for the correct `account locator IDs <https://docs.
      - aws_us_west_2
      - EXB14788
 
+   * - aws-prod-cc1
+     - aws_ca_central_1
+     - QN44389
+
    * - az-prod
      - azure_centralus
      - TN88732


### PR DESCRIPTION
New custodial Snowflake account amperity_bridge_apcc1acc1_1o66 (business critical edition) for the `aws-prod-cc1` stack in Snowflake region `aws_ca_central_1`, per a halp request. Follows the provisioning runbook in service/bridge/README.md.

Amperity stack: `aws-prod-cc1`
Snowflake region: `aws_ca_central_1`
Account locator: `QN44389`