### PR TITLE
Add Snowflake Cortex MCP setup guide (AI-2300)

### DIFF
--- a/amperity_api/source/index.rst
+++ b/amperity_api/source/index.rst
@@ -94,6 +94,7 @@ Amperity has an `OpenAPI specification <https://docs.amperity.com/api/openapi.ht
    Set up Claude <mcp_setup_claude>
    Set up Copilot Studio <mcp_setup_m365_copilot>
    Set up Gemini <mcp_setup_gemini>
+   Set up Snowflake Cortex <mcp_setup_snowflake_cortex>
    Safety modes <mcp_safety_modes>
    Tools reference <mcp_tool_reference>
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -100,5 +100,6 @@ Connect a client to the MCP server:
 * :doc:`Claude.ai, Claude Desktop, and Claude Code <mcp_setup_claude>`
 * :doc:`Copilot Studio <mcp_setup_m365_copilot>`
 * :doc:`Gemini -- Antigravity and Gemini CLI <mcp_setup_gemini>`
+* :doc:`Snowflake Cortex Agents <mcp_setup_snowflake_cortex>`
 
 .. mcp-connect-client-end

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -22,12 +22,13 @@ Set up Snowflake Cortex
 
 Connect Snowflake Cortex Agents to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once registered, you can attach the Amperity MCP server to any Cortex Agent so the agent can call Amperity tools directly from Snowflake.
 
-Configuration happens in SQL and follows four steps:
+Setup involves five steps:
 
 #. :ref:`Create an API integration <mcp-setup-cortex-integration>` that points at the Amperity MCP server and its OAuth endpoints.
 #. :ref:`Register the external MCP server <mcp-setup-cortex-register>` through that integration.
 #. :ref:`Grant usage <mcp-setup-cortex-grant>` on the server and integration to the roles that need it.
-#. :ref:`Authorize the connection <mcp-setup-cortex-authorize>` by completing an OAuth sign-in to Amperity.
+#. :ref:`Authorize the connection <mcp-setup-cortex-authorize>` by signing in to Amperity with OAuth.
+#. :ref:`Attach the server to a Cortex Agent <mcp-setup-cortex-attach>` so the agent can call Amperity tools.
 
 For details on Snowflake's external MCP connector feature, see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__.
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -22,13 +22,14 @@ Set up Snowflake Cortex
 
 Connect Snowflake Cortex Agents to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once registered, you can attach the Amperity MCP server to any Cortex Agent so the agent can call Amperity tools directly from Snowflake.
 
-Setup involves five steps:
+Setup involves four steps:
 
 #. :ref:`Create an API integration <mcp-setup-cortex-integration>` that points at the Amperity MCP server and its OAuth endpoints.
 #. :ref:`Register the external MCP server <mcp-setup-cortex-register>` through that integration.
 #. :ref:`Grant usage <mcp-setup-cortex-grant>` on the server and integration to the roles that need it.
 #. :ref:`Authorize the connection <mcp-setup-cortex-authorize>` by signing in to Amperity with OAuth.
-#. :ref:`Attach the server to a Cortex Agent <mcp-setup-cortex-attach>` so the agent can call Amperity tools.
+
+Once you authorize, the Amperity MCP server is available in CoCo and Snowflake Intelligence. To make the Amperity tools part of a specific Cortex Agent's saved definition, optionally :ref:`attach the server to that agent <mcp-setup-cortex-attach>`.
 
 For details on Snowflake's external MCP connector feature, see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__.
 
@@ -140,12 +141,14 @@ A browser tab opens. Sign in with your Amperity credentials and select your tena
 
 .. _mcp-setup-cortex-attach:
 
-Attach the server to a Cortex Agent
+Attach the server to a Cortex Agent (optional)
 ==================================================
 
 .. mcp-setup-cortex-attach-start
 
-Add the Amperity MCP server to a Cortex Agent so the agent can call Amperity tools. Update the agent's specification to reference the server object by its fully qualified name. Keep your existing agent specification and add the ``mcp_servers`` block. Replace ``<agent_name>`` and the ``<db>.<schema>`` prefix to match your environment:
+This step is optional. After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach the server to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools.
+
+Update the agent's specification to reference the server object by its fully qualified name. Keep your existing agent specification and add the ``mcp_servers`` block. Replace ``<agent_name>`` and the ``<db>.<schema>`` prefix to match your environment:
 
 .. code-block:: sql
 
@@ -175,7 +178,7 @@ Confirm the server is registered and that the agent can reach Amperity.
       SHOW EXTERNAL MCP SERVERS IN ACCOUNT;
       DESCRIBE EXTERNAL MCP SERVER <db>.<schema>.amperity_mcp;
 
-#. Prompt a Cortex Agent that has the Amperity MCP server attached:
+#. In CoCo, Snowflake Intelligence, or a Cortex Agent with the Amperity MCP connector enabled, prompt:
 
    .. code-block:: none
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -146,18 +146,7 @@ Attach the server to a Cortex Agent (optional)
 
 .. mcp-setup-cortex-attach-start
 
-After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach the server to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools.
-
-Update the agent's specification to reference the server object by its fully qualified name. Keep your existing agent specification and add the ``mcp_servers`` block. Replace ``<agent_name>`` and the ``<db>.<schema>`` prefix to match your environment:
-
-.. code-block:: sql
-
-   ALTER AGENT <agent_name> MODIFY LIVE VERSION SET SPECIFICATION $$
-     <...your existing agent spec...>
-     mcp_servers:
-       - server_spec:
-           name: "<db>.<schema>.amperity_mcp"
-   $$;
+After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach it to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools--for example, to share a purpose-built agent with a team or to invoke one through the Agent REST API. Add the server to the agent's ``mcp_servers`` specification; see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__ for the specification syntax.
 
 .. mcp-setup-cortex-attach-end
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -20,7 +20,7 @@ Set up Snowflake Cortex
 
 .. mcp-setup-cortex-start
 
-Connect Snowflake Cortex Agents to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once registered, you can attach the Amperity MCP server to any Cortex Agent so the agent can call Amperity tools directly from Snowflake.
+Connect Snowflake Cortex to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once connected, CoCo, Snowflake Intelligence, and Cortex Agents can call Amperity tools directly from Snowflake.
 
 Setup involves four steps:
 
@@ -29,7 +29,7 @@ Setup involves four steps:
 #. :ref:`Grant usage <mcp-setup-cortex-grant>` on the server and integration to the roles that need it.
 #. :ref:`Authorize the connection <mcp-setup-cortex-authorize>` by signing in to Amperity with OAuth.
 
-Once you authorize, the Amperity MCP server is available in CoCo and Snowflake Intelligence. To make the Amperity tools part of a specific Cortex Agent's saved definition, optionally :ref:`attach the server to that agent <mcp-setup-cortex-attach>`.
+Once you authorize, the Amperity MCP server is available in CoCo and Snowflake Intelligence.
 
 For details on Snowflake's external MCP connector feature, see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__.
 
@@ -137,18 +137,6 @@ Before the server can be used, each user signs in to Amperity with OAuth. Author
 A browser tab opens. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
 
 .. mcp-setup-cortex-authorize-end
-
-
-.. _mcp-setup-cortex-attach:
-
-Attach the server to a Cortex Agent (optional)
-==================================================
-
-.. mcp-setup-cortex-attach-start
-
-After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach it to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools--for example, to share a purpose-built agent with a team or to invoke one through the Agent REST API. Add the server to the agent's ``mcp_servers`` specification; see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__ for the specification syntax.
-
-.. mcp-setup-cortex-attach-end
 
 
 .. _mcp-setup-cortex-verify:

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -76,7 +76,7 @@ Create an API integration that allows Snowflake to reach the Amperity MCP server
 
 ``OAUTH_CLIENT_ID`` is Amperity's public MCP client ID and is the same for every customer.
 
-.. important:: The Amperity MCP server is a public OAuth client that uses PKCE and does not issue a client secret. Snowflake still requires ``OAUTH_CLIENT_SECRET`` to be non-empty, so supply any non-empty placeholder value, such as ``placeholder``. This is expected and does not weaken the connection.
+.. important:: The Amperity MCP server is a public OAuth client that uses PKCE and does not issue a client secret. Snowflake still requires ``OAUTH_CLIENT_SECRET`` to be non-empty, so supply any non-empty placeholder value, such as ``placeholder``.
 
 .. mcp-setup-cortex-integration-end
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -44,8 +44,8 @@ Requirements
 Connecting Snowflake Cortex to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
-* The ``ACCOUNTADMIN`` role, or a role with the ``CREATE INTEGRATION`` privilege, to create the API integration and the external MCP server.
-* ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection, such as the analyst role behind a Cortex Agent.
+* The ``ACCOUNTADMIN`` role to create the API integration and the external MCP server. By default, only account admins hold these privileges. A non-admin role can perform setup only if it has been granted the privilege to create an API integration and ``CREATE EXTERNAL MCP SERVER`` on the target schema.
+* ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection.
 
 .. mcp-setup-cortex-requirements-end
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -44,7 +44,7 @@ Requirements
 Connecting Snowflake Cortex to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
-* A Snowflake account in a supported region and cloud. The examples on this page use AWS ``us-west-2``.
+* A Snowflake account in a region and cloud where external MCP connectors are available. See the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__ for current availability.
 * The ``ACCOUNTADMIN`` role, or a role with the ``CREATE INTEGRATION`` privilege, to create the API integration and the external MCP server.
 * ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection, such as the analyst role behind a Cortex Agent.
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -20,7 +20,7 @@ Set up Snowflake Cortex
 
 .. mcp-setup-cortex-start
 
-Connect Snowflake Cortex to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once connected, CoCo (Snowflake's Cortex Code assistant), Snowflake Intelligence, and Cortex Agents can call Amperity tools directly from Snowflake.
+Connect Snowflake Cortex to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once connected, CoCo (Cortex Code), Snowflake Intelligence, and Cortex Agents can call Amperity tools directly from Snowflake.
 
 Setup involves four steps:
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -57,7 +57,7 @@ Create an API integration
 
 .. mcp-setup-cortex-integration-start
 
-Create an API integration that allows Snowflake to reach the Amperity MCP server and complete the OAuth handshake. Run the following as ``ACCOUNTADMIN`` (or a role with ``CREATE INTEGRATION``):
+Create an API integration that allows Snowflake to reach the Amperity MCP server and complete the OAuth handshake. Run the following as ``ACCOUNTADMIN``:
 
 .. code-block:: sql
 
@@ -88,7 +88,7 @@ Register the external MCP server
 
 .. mcp-setup-cortex-register-start
 
-Register the Amperity MCP server as an external MCP server through the integration you just created. The server object is created in your current database and schema, so set your context first. Replace ``<db>`` and ``<schema>`` with the database and schema where you want the server object to live:
+Register the Amperity MCP server through the integration you just created. The server object is created in your current database and schema, so set your context first. Replace ``<db>`` and ``<schema>`` with the database and schema where you want the server object to live:
 
 .. code-block:: sql
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -161,8 +161,6 @@ Confirm the server is registered and that the agent can reach Amperity.
 
       "Tell me about my Amperity tenant."
 
-   The agent calls the **tenant_info** tool and returns details about your current Amperity tenant. This confirms the connection end to end.
-
-.. note:: Cortex Agent MCP tool calls are not written to Snowflake's monitoring tables. To confirm a tool ran, review the agent's live tool-invocation trace rather than looking for a query in your account history.
+   The agent calls the **tenant_info** tool and returns details about your current Amperity tenant.
 
 .. mcp-setup-cortex-verify-end

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -1,0 +1,192 @@
+.. https://docs.amperity.com/api/
+
+
+.. meta::
+    :description lang=en:
+        Configure Snowflake Cortex Agents to connect to the Amperity MCP server.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Snowflake Cortex Agents to connect to the Amperity MCP server.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Set up Snowflake Cortex
+
+
+==================================================
+Set up Snowflake Cortex
+==================================================
+
+.. mcp-setup-cortex-start
+
+Connect Snowflake Cortex Agents to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once registered, you can attach the Amperity MCP server to any Cortex Agent so the agent can call Amperity tools directly from Snowflake.
+
+Configuration happens in SQL and follows four steps:
+
+#. :ref:`Create an API integration <mcp-setup-cortex-integration>` that points at the Amperity MCP server and its OAuth endpoints.
+#. :ref:`Register the external MCP server <mcp-setup-cortex-register>` through that integration.
+#. :ref:`Grant usage <mcp-setup-cortex-grant>` on the server and integration to the roles that need it.
+#. :ref:`Authorize the connection <mcp-setup-cortex-authorize>` by completing an OAuth sign-in to Amperity.
+
+For details on Snowflake's external MCP connector feature, see the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__.
+
+.. mcp-setup-cortex-end
+
+
+.. _mcp-setup-cortex-requirements:
+
+Requirements
+==================================================
+
+.. mcp-setup-cortex-requirements-start
+
+Connecting Snowflake Cortex to the MCP server requires:
+
+* An active Amperity account with access to at least one tenant.
+* A Snowflake account in a supported region and cloud. The examples on this page use AWS ``us-west-2``.
+* The ``ACCOUNTADMIN`` role, or a role with the ``CREATE INTEGRATION`` privilege, to create the API integration and the external MCP server.
+* ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection, such as the analyst role behind a Cortex Agent.
+
+.. mcp-setup-cortex-requirements-end
+
+
+.. _mcp-setup-cortex-integration:
+
+Create an API integration
+==================================================
+
+.. mcp-setup-cortex-integration-start
+
+Create an API integration that allows Snowflake to reach the Amperity MCP server and complete the OAuth handshake. Run the following as ``ACCOUNTADMIN`` (or a role with ``CREATE INTEGRATION``):
+
+.. code-block:: sql
+
+   CREATE OR REPLACE API INTEGRATION amperity_mcp_integration
+     API_PROVIDER = external_mcp
+     API_ALLOWED_PREFIXES = ('https://mcp.amperity.com')
+     API_USER_AUTHENTICATION = (
+       TYPE = oauth2
+       OAUTH_CLIENT_ID = 'nwbd0MGCyh1VysmYQM05UoDXIuVPdGEs'
+       OAUTH_CLIENT_SECRET = 'placeholder'
+       OAUTH_TOKEN_ENDPOINT = 'https://mcp.amperity.com/oauth/token'
+       OAUTH_AUTHORIZATION_ENDPOINT = 'https://mcp.amperity.com/authorize'
+       OAUTH_RESOURCE_URL = 'https://mcp.amperity.com'
+     )
+     ENABLED = true;
+
+``OAUTH_CLIENT_ID`` is Amperity's public MCP client ID and is the same for every customer.
+
+.. important:: The Amperity MCP server is a public OAuth client that uses PKCE and does not issue a client secret. Snowflake still requires ``OAUTH_CLIENT_SECRET`` to be non-empty, so supply any non-empty placeholder value, such as ``placeholder``. This is expected and does not weaken the connection.
+
+.. mcp-setup-cortex-integration-end
+
+
+.. _mcp-setup-cortex-register:
+
+Register the external MCP server
+==================================================
+
+.. mcp-setup-cortex-register-start
+
+Register the Amperity MCP server as an external MCP server through the integration you just created. The server object is created in your current database and schema, so set your context first. Replace ``<db>`` and ``<schema>`` with the database and schema where you want the server object to live:
+
+.. code-block:: sql
+
+   USE DATABASE <db>;
+   USE SCHEMA <schema>;
+
+   CREATE EXTERNAL MCP SERVER amperity_mcp
+     WITH DISPLAY_NAME = 'Amperity MCP'
+     URL = 'https://mcp.amperity.com'
+     API_INTEGRATION = amperity_mcp_integration;
+
+.. mcp-setup-cortex-register-end
+
+
+.. _mcp-setup-cortex-grant:
+
+Grant usage
+==================================================
+
+.. mcp-setup-cortex-grant-start
+
+Grant ``USAGE`` on both the external MCP server and the API integration to the role that will use the connection. Replace ``<analyst_role>`` with the role behind your Cortex Agent:
+
+.. code-block:: sql
+
+   GRANT USAGE ON EXTERNAL MCP SERVER amperity_mcp TO ROLE <analyst_role>;
+   GRANT USAGE ON INTEGRATION amperity_mcp_integration TO ROLE <analyst_role>;
+
+.. mcp-setup-cortex-grant-end
+
+
+.. _mcp-setup-cortex-authorize:
+
+Authorize the connection
+==================================================
+
+.. mcp-setup-cortex-authorize-start
+
+Before the server can be used, each user completes a one-time OAuth sign-in to Amperity. Authorize from Snowsight or from SQL:
+
+* In Snowsight, go to **CoWork** > **Connectors**, find the Amperity connector, and select **Connect**.
+* From SQL, start the flow directly:
+
+  .. code-block:: sql
+
+     SELECT SYSTEM$START_USER_OAUTH_FLOW('amperity_mcp_integration');
+
+Either path opens a browser tab. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
+
+.. mcp-setup-cortex-authorize-end
+
+
+.. _mcp-setup-cortex-attach:
+
+Attach the server to a Cortex Agent
+==================================================
+
+.. mcp-setup-cortex-attach-start
+
+Add the Amperity MCP server to a Cortex Agent so the agent can call Amperity tools. Update the agent's specification to reference the server object by its fully qualified name. Keep your existing agent specification and add the ``mcp_servers`` block. Replace ``<agent_name>`` and the ``<db>.<schema>`` prefix to match your environment:
+
+.. code-block:: sql
+
+   ALTER AGENT <agent_name> MODIFY LIVE VERSION SET SPECIFICATION $$
+     <...your existing agent spec...>
+     mcp_servers:
+       - server_spec:
+           name: "<db>.<schema>.amperity_mcp"
+   $$;
+
+.. mcp-setup-cortex-attach-end
+
+
+.. _mcp-setup-cortex-verify:
+
+Verify the connection
+==================================================
+
+.. mcp-setup-cortex-verify-start
+
+Confirm the server is registered and that the agent can reach Amperity.
+
+#. Confirm the server exists and inspect its configuration:
+
+   .. code-block:: sql
+
+      SHOW EXTERNAL MCP SERVERS IN ACCOUNT;
+      DESCRIBE EXTERNAL MCP SERVER <db>.<schema>.amperity_mcp;
+
+#. Prompt a Cortex Agent that has the Amperity MCP server attached:
+
+   .. code-block:: none
+
+      "List my Amperity tenants."
+
+   The agent calls the **tenant_list** tool and returns the tenants available to your Amperity account. This confirms the connection end to end.
+
+.. note:: Cortex Agent MCP tool calls are not written to Snowflake's monitoring tables. To confirm a tool ran, review the agent's live tool-invocation trace rather than looking for a query in your account history.
+
+.. mcp-setup-cortex-verify-end

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -171,9 +171,9 @@ Confirm the server is registered and that the agent can reach Amperity.
 
    .. code-block:: none
 
-      "List my Amperity tenants."
+      "Tell me about my Amperity tenant."
 
-   The agent calls the **tenant_list** tool and returns the tenants available to your Amperity account. This confirms the connection end to end.
+   The agent calls the **tenant_info** tool and returns details about your current Amperity tenant. This confirms the connection end to end.
 
 .. note:: Cortex Agent MCP tool calls are not written to Snowflake's monitoring tables. To confirm a tool ran, review the agent's live tool-invocation trace rather than looking for a query in your account history.
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -20,7 +20,7 @@ Set up Snowflake Cortex
 
 .. mcp-setup-cortex-start
 
-Connect Snowflake Cortex to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once connected, CoCo, Snowflake Intelligence, and Cortex Agents can call Amperity tools directly from Snowflake.
+Connect Snowflake Cortex to the Amperity MCP server by registering it as an external MCP server and signing in with your Amperity credentials. Once connected, CoCo (Snowflake's Cortex Code assistant), Snowflake Intelligence, and Cortex Agents can call Amperity tools directly from Snowflake.
 
 Setup involves four steps:
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -130,7 +130,7 @@ Authorize the connection
 
 Before the server can be used, each user completes a one-time OAuth sign-in to Amperity. Authorize from Snowsight or from SQL:
 
-* In Snowsight, go to **CoWork** > **Connectors**, find the Amperity connector, and select **Connect**.
+* In Snowsight, open the **MCP connectors** page under **Settings** > **Cortex**, find the **Amperity MCP** connector, and select **Connect**. You can also reach this page by selecting the Amperity MCP connector from any Cortex chat.
 * From SQL, start the flow directly:
 
   .. code-block:: sql

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -110,7 +110,7 @@ Grant usage
 
 .. mcp-setup-cortex-grant-start
 
-Grant ``USAGE`` on both the external MCP server and the API integration to the role that will use the connection. Replace ``<analyst_role>`` with the role behind your Cortex Agent:
+Grant ``USAGE`` on both the external MCP server and the API integration to the role used by anyone who will query the agent. Replace ``<analyst_role>`` with that role:
 
 .. code-block:: sql
 
@@ -127,7 +127,7 @@ Authorize the connection
 
 .. mcp-setup-cortex-authorize-start
 
-Before the server can be used, each user completes a one-time OAuth sign-in to Amperity. Authorize from Snowsight or from SQL:
+Before the server can be used, each user signs in to Amperity with OAuth. Authorize from Snowsight or from SQL:
 
 * In Snowsight, open the **MCP connectors** page under **Settings** > **Cortex**, find the **Amperity MCP** connector, and select **Connect**. You can also reach this page by selecting the Amperity MCP connector from any Cortex chat.
 * From SQL, start the flow directly:
@@ -137,6 +137,8 @@ Before the server can be used, each user completes a one-time OAuth sign-in to A
      SELECT SYSTEM$START_USER_OAUTH_FLOW('amperity_mcp_integration');
 
 Either path opens a browser tab. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
+
+.. tip:: The stored token expires. When it does, the agent returns an authorization error--repeat the sign-in above to reauthorize.
 
 .. mcp-setup-cortex-authorize-end
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -127,16 +127,12 @@ Authorize the connection
 
 .. mcp-setup-cortex-authorize-start
 
-Before the server can be used, each user signs in to Amperity with OAuth. Authorize from Snowsight or from SQL:
+Before the server can be used, each user signs in to Amperity with OAuth. Authorize from the Snowflake interface where you use the agent:
 
-* In Snowsight, open the **MCP connectors** page under **Settings** > **Cortex**, find the **Amperity MCP** connector, and select **Connect**. You can also reach this page by selecting the Amperity MCP connector from any Cortex chat.
-* From SQL, start the flow directly:
+* In Snowflake Intelligence, select **+** in the message box, choose **Connectors**, then select **Connect** next to **Amperity MCP**.
+* In Snowsight, open the **MCP connectors** page under **Settings** > **Cortex**, find the **Amperity MCP** connector, and select **Connect**.
 
-  .. code-block:: sql
-
-     SELECT SYSTEM$START_USER_OAUTH_FLOW('amperity_mcp_integration');
-
-Either path opens a browser tab. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
+A browser tab opens. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
 
 .. tip:: The stored token expires. When it does, the agent returns an authorization error--repeat the sign-in above to reauthorize.
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -146,7 +146,7 @@ Attach the server to a Cortex Agent (optional)
 
 .. mcp-setup-cortex-attach-start
 
-This step is optional. After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach the server to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools.
+After you authorize the connection, the Amperity MCP server is already available in CoCo and Snowflake Intelligence. Attach the server to a Cortex Agent only when you want a specific agent's saved definition to always include the Amperity tools.
 
 Update the agent's specification to reference the server object by its fully qualified name. Keep your existing agent specification and add the ``mcp_servers`` block. Replace ``<agent_name>`` and the ``<db>.<schema>`` prefix to match your environment:
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -44,7 +44,6 @@ Requirements
 Connecting Snowflake Cortex to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
-* A Snowflake account in a region and cloud where external MCP connectors are available. See the `Snowflake documentation <https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors>`__ for current availability.
 * The ``ACCOUNTADMIN`` role, or a role with the ``CREATE INTEGRATION`` privilege, to create the API integration and the external MCP server.
 * ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection, such as the analyst role behind a Cortex Agent.
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -135,8 +135,6 @@ Before the server can be used, each user signs in to Amperity with OAuth. Author
 
 A browser tab opens. Sign in with your Amperity credentials and select your tenant. Snowflake stores the resulting token for your user.
 
-.. tip:: The stored token expires. When it does, the agent returns an authorization error--repeat the sign-in above to reauthorize.
-
 .. mcp-setup-cortex-authorize-end
 
 

--- a/amperity_api/source/mcp_setup_snowflake_cortex.rst
+++ b/amperity_api/source/mcp_setup_snowflake_cortex.rst
@@ -44,7 +44,7 @@ Requirements
 Connecting Snowflake Cortex to the MCP server requires:
 
 * An active Amperity account with access to at least one tenant.
-* The ``ACCOUNTADMIN`` role to create the API integration and the external MCP server. By default, only account admins hold these privileges. A non-admin role can perform setup only if it has been granted the privilege to create an API integration and ``CREATE EXTERNAL MCP SERVER`` on the target schema.
+* The ``ACCOUNTADMIN`` role to create the API integration and the external MCP server.
 * ``USAGE`` on both the external MCP server object and the API integration for any role that will use the connection.
 
 .. mcp-setup-cortex-requirements-end


### PR DESCRIPTION
Adds a customer-facing setup guide for connecting Snowflake Cortex Agents to the hosted Amperity MCP server (`https://mcp.amperity.com`) via an external MCP connector.

## What's here
- New page: `amperity_api/source/mcp_setup_snowflake_cortex.rst`, matching the existing Gemini/Copilot setup-guide style.
- Covers: requirements → create API integration → register external MCP server → grant usage → authorize (Snowsight + SQL) → attach to a Cortex Agent → verify.
- Wired into the API section toctree (`index.rst`) and the "Connect a client" list (`mcp_overview.rst`).

## Verified working
Confirmed end to end in Snowsight: the **Amperity MCP** connector shows Connected, and a Cortex Intelligence agent (CoCo) successfully ran Amperity tools (`session_start`, `tenant_use`). The prior blocker (Snowflake sends the placeholder OAuth secret as HTTP Basic auth) is resolved by amperity-mcp #732, now live on `mcp.amperity.com`.

## Notes
- No sensitive secrets: the `client_id` is Amperity's public MCP client; the `OAUTH_CLIENT_SECRET` is a documented non-empty placeholder.
- Reference: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp-connectors

Builds clean with `make api` (`-W`, warnings-as-errors).