### PR TITLE
Document MCP token usage in server overview

### DIFF
--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -94,7 +94,7 @@ Does the MCP server use tokens?
 
 .. mcp-token-usage-start
 
-Enabling the Amperity MCP server does not use tokens. The MCP server is a connector to your Amperity data; connecting a client does not consume tokens on the Amperity side.
+Enabling the Amperity MCP server does not use tokens, and it does not directly consume amps. The MCP server is a connector to your Amperity data; connecting a client does not consume tokens or amps on the Amperity side.
 
 Tokens are consumed by your AI client when its agent calls a tool and processes the response. That usage is metered and billed within your own AI platform, such as Claude or ChatGPT, and never by Amperity. The more data an agent pulls, the more tokens it uses.
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -89,14 +89,16 @@ The Amperity MCP server does not:
 
 .. _mcp-token-usage:
 
-Does the MCP server use tokens?
+Does the MCP server use tokens or amps?
 ==================================================
 
 .. mcp-token-usage-start
 
-Enabling the Amperity MCP server does not use tokens, and it does not directly consume amps. The MCP server is a connector to your Amperity data; connecting a client does not consume tokens or amps on the Amperity side.
+Enabling the Amperity MCP server does not use tokens, and connecting a client does not by itself consume amps. The MCP server is a connector to your Amperity data.
 
 Tokens are consumed by your AI client when its agent calls a tool and processes the response. That usage is metered and billed within your own AI platform, such as Claude or ChatGPT, and never by Amperity. The more data an agent pulls, the more tokens it uses.
+
+Amps (Amperity's usage credits) are consumed when an agent runs an operation that does work, such as kicking off a database run or identity resolution. This is the same amp consumption you would incur by running that operation in the Amperity UI. Running the operation through the MCP server does not add any extra amp cost.
 
 .. mcp-token-usage-end
 

--- a/amperity_api/source/mcp_overview.rst
+++ b/amperity_api/source/mcp_overview.rst
@@ -87,6 +87,20 @@ The Amperity MCP server does not:
 .. mcp-what-mcp-not-enabled-end
 
 
+.. _mcp-token-usage:
+
+Does the MCP server use tokens?
+==================================================
+
+.. mcp-token-usage-start
+
+Enabling the Amperity MCP server does not use tokens. The MCP server is a connector to your Amperity data; connecting a client does not consume tokens on the Amperity side.
+
+Tokens are consumed by your AI client when its agent calls a tool and processes the response. That usage is metered and billed within your own AI platform, such as Claude or ChatGPT, and never by Amperity. The more data an agent pulls, the more tokens it uses.
+
+.. mcp-token-usage-end
+
+
 .. _mcp-connect-client:
 
 Connect a client


### PR DESCRIPTION
## Summary

Adds a short section to the MCP server overview covering token and amp usage. Enabling the MCP server does not use tokens, and connecting a client does not by itself consume amps. Tokens are metered by the customer's own AI platform (Claude, ChatGPT, etc.). Amps are consumed when an agent runs an operation that does work (e.g. a database run), the same as running it in the UI, with no extra MCP cost. Answers a recurring customer question. Tracked in JB-17.

## Changes

New `Does the MCP server use tokens or amps?` section in `mcp_overview.rst`, following the existing Q&A heading pattern and start/end include markers.

## How was this change tested?

Docs-only change. Reviewed rendered structure against the surrounding sections; no build config touched.

## Rollout

Ships with the next docs publish. No flags, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
