### PR TITLE
Remove unused PyJWT dependency and dead Canny SSO block

### DIFF
--- a/amperity_amp360/source/conf.py
+++ b/amperity_amp360/source/conf.py
@@ -18,22 +18,6 @@ import sys, os
 sys.path.append(os.path.abspath('../../_ext'))
 
 
-# might be needed for Canny, if yes, should be here
-# import jwt
-# 
-# canny_private_key = 'bd4601a9-32d6-8632-ac89-cd091e213c0b'
-# 
-# def create_canny_token(user):
-#   user_data = {
-#     'avatarURL': user.avatar_url, # optional but preferred
-#     'email': user.email,
-#     'id': user.id,
-#     'name': user.name,
-#   }
-#   return jwt.encode(user_data, canny_private_key, algorithm='HS256')
-# 
-
-
 # -- General configuration -----------------------------------------------------
 
 

--- a/amperity_ampiq/source/conf.py
+++ b/amperity_ampiq/source/conf.py
@@ -18,22 +18,6 @@ import sys, os
 sys.path.append(os.path.abspath('../../_ext'))
 
 
-# might be needed for Canny, if yes, should be here
-# import jwt
-# 
-# canny_private_key = 'bd4601a9-32d6-8632-ac89-cd091e213c0b'
-# 
-# def create_canny_token(user):
-#   user_data = {
-#     'avatarURL': user.avatar_url, # optional but preferred
-#     'email': user.email,
-#     'id': user.id,
-#     'name': user.name,
-#   }
-#   return jwt.encode(user_data, canny_private_key, algorithm='HS256')
-# 
-
-
 # -- General configuration -----------------------------------------------------
 
 

--- a/amperity_datagrid/source/conf.py
+++ b/amperity_datagrid/source/conf.py
@@ -18,22 +18,6 @@ import sys, os
 sys.path.append(os.path.abspath('../../_ext'))
 
 
-# might be needed for Canny, if yes, should be here
-# import jwt
-# 
-# canny_private_key = 'bd4601a9-32d6-8632-ac89-cd091e213c0b'
-# 
-# def create_canny_token(user):
-#   user_data = {
-#     'avatarURL': user.avatar_url, # optional but preferred
-#     'email': user.email,
-#     'id': user.id,
-#     'name': user.name,
-#   }
-#   return jwt.encode(user_data, canny_private_key, algorithm='HS256')
-# 
-
-
 # -- General configuration -----------------------------------------------------
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ sphinxcontrib-mermaid==1.0.0
 sphinxcontrib-video==0.4.1
 sphinxcontrib-youtube==1.4.1
 sphinx-new-tab-link==0.8.0
-PyJWT==2.4.0
 Pygments==2.19.1


### PR DESCRIPTION
# DON'T STORE PRIVATE KEYS IN REPOS

seems this was migrated over from private repo, has been public for a while

noticed this while removing the unused PyJWT from dependencies