### PR TITLE
AMP-28: Document IQ audience counts

### DIFF
--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -587,6 +587,8 @@ Manage segments and folders.
 
        **iq_get**
 
+       **iq_count**
+
        **iq_create**
 
        **iq_update**


### PR DESCRIPTION
**Customer impact:** Customers can find the public reference for retrieving an exact saved-segment audience count with `iq_count`.

- Adds `iq_count` alongside the existing IQ tools without changing `iq_list` or `iq_get`.
- **Testing:** strict Sphinx 7.3.7 API build passed with warnings treated as errors.
- **Rollout:** Keep draft; merge only after app PR [#71251] is deployed and confirmed in production.

[AMP-28]

[AMP-28]: https://linear.app/amperity/issue/AMP-28/return-audience-counts-with-iq-segment-getlist-commands
