### PR TITLE
AMP-29: Document user provisioning tools

### DIFF
--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -147,9 +147,9 @@ Create the identity, then grant access in the parent and sandbox independently::
    user_create(name="Avery Chen", email="avery@example.com", confirm=true)
    # => {"result": "ok", "user_id": "auth0|...", ...}
 
-   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-operator")
+   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-operator", confirm=true)
    tenant_use(tenant_name="customer-sb-analysis", confirm=true)
-   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-administrator")
+   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-administrator", confirm=true)
 
 Remove only the sandbox's direct access; the parent attachment is unchanged::
 

--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -85,7 +85,9 @@ Manage which Amperity tenant the current session targets, and read session-level
 Users and access
 ==================================================
 
-Find and create global Amperity users, inspect policies, and manage a user's direct unscoped policy attachments in the current tenant.
+Manage global Amperity user identities and their tenant access. A *global identity* is the
+single login record shared across the parent tenant and its sandboxes; a tenant policy
+attachment is the separate record that grants that identity access in one tenant.
 
 .. list-table::
    :header-rows: 1
@@ -94,18 +96,85 @@ Find and create global Amperity users, inspect policies, and manage a user's dir
    * - Description
      - Tools
 
-   * - Find and create users
+   * - Find, create, and delete users
      - **user_list**
 
        **user_create**
 
+       **user_delete**
+
    * - Inspect policies
      - **policy_list**
 
-   * - Grant and revoke direct unscoped policies
+   * - Grant and revoke direct policies
      - **user_grant_policy**
 
        **user_revoke_policy**
+
+       **user_revoke_all_policies**
+
+
+User lifecycle and access boundaries
+------------------------------------
+
+``user_create`` creates or returns the exact global identity for an email. It does not
+grant access in the selected tenant. ``confirm=true`` is always required because the
+identity is global, even when the selected tenant is a sandbox.
+
+``user_delete`` takes the exact ``user_id`` returned by ``user_create`` and performs a
+hard global deletion. It must be called from the parent tenant context with
+``confirm=true``. It is not a sandbox-only removal: deleting the identity disables its
+access everywhere that uses that identity. Do not retry a result of ``unknown`` blindly;
+use its reconciliation state and inspect direct access separately.
+
+``user_revoke_policy`` removes one direct policy attachment. ``user_revoke_all_policies``
+removes all active direct attachments for that user in the selected tenant, including
+resource-group-scoped attachments (attachments limited to a named data resource group).
+It does not remove group-mapped access, which is access inherited from a group mapping,
+and it does not represent a user deactivation state. The platform currently has no
+separate reversible ``user_deactivate`` operation in this MCP surface.
+
+The bulk tool materializes the attachment list before changing anything and returns
+removed, already-absent, remaining, and unattempted IDs. ``partial`` means some known
+changes happened but access remains or a deterministic failure stopped the pass;
+``unknown`` means a response or final check could not establish the current state.
+
+Worked examples
+---------------
+
+Create the identity, then grant access in the parent and sandbox independently::
+
+   user_create(name="Avery Chen", email="avery@example.com", confirm=true)
+   # => {"result": "ok", "user_id": "auth0|...", ...}
+
+   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-operator")
+   tenant_use(tenant_name="customer-sb-analysis", confirm=true)
+   user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-administrator")
+
+Remove only the sandbox's direct access; the parent attachment is unchanged::
+
+   user_revoke_all_policies(user_id="auth0|...", confirm=true)
+   # => {"result": "ok", "scope": "selected_tenant", "changed": true, ...}
+
+For a complete offboarding, run direct cleanup in each tenant first when possible, then
+delete the global identity from the parent context::
+
+   tenant_use(tenant_name="customer", confirm=true)
+   user_revoke_all_policies(user_id="auth0|...", confirm=true)
+   user_delete(user_id="auth0|...", confirm=true)
+   # => {"result": "ok", "scope": "global", "changed": true}
+
+Close cases:
+
+* ``user_revoke_all_policies`` returning ``changed=false`` means no active direct
+  attachment changed. It does not prove that group-mapped access is absent.
+* ``user_delete`` returning ``unknown`` is not a failure you should replay as a second
+  delete. The identity may already be gone while backend cleanup or event publication
+  remains unverified.
+* A ``partial`` bulk result is actionable: use ``remaining_attachment_ids`` to inspect
+  what still grants direct access. ``user_delete`` and direct-policy cleanup are separate
+  operations, so deleting the identity does not make a partial tenant cleanup result
+  disappear from the audit trail.
 
 
 .. _mcp-tool-databases:

--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -111,33 +111,24 @@ attachment is the separate record that grants that identity access in one tenant
 
        **user_revoke_policy**
 
-       **user_revoke_all_policies**
-
 
 User lifecycle and access boundaries
 ------------------------------------
 
-``user_create`` creates or returns the exact global identity for an email. It does not
-grant access in the selected tenant. ``confirm=true`` is always required because the
-identity is global, even when the selected tenant is a sandbox.
+``user_list`` lists global identities visible from the selected tenant, and
+``policy_list`` lists policies assignable there. ``user_create`` creates a global
+identity for an email but does not grant tenant access. It runs only from the parent
+tenant and requires ``confirm=true``; sending an invitation also requires unrestricted
+safety mode.
 
-``user_delete`` takes the exact ``user_id`` returned by ``user_create`` and performs a
-hard global deletion. It must be called from the parent tenant context with
-``confirm=true``. It is not a sandbox-only removal: deleting the identity disables its
-access everywhere that uses that identity. Do not retry a result of ``unknown`` blindly;
-use its reconciliation state and inspect direct access separately.
+``user_grant_policy`` and ``user_revoke_policy`` add or remove one exact direct policy
+attachment in the selected tenant. They take the ``user_id`` and ``policy_id`` returned
+by the list or create tools. Revoking a direct policy does not remove access inherited
+from a group mapping.
 
-``user_revoke_policy`` removes one direct policy attachment. ``user_revoke_all_policies``
-removes all active direct attachments for that user in the selected tenant, including
-resource-group-scoped attachments (attachments limited to a named data resource group).
-It does not remove group-mapped access, which is access inherited from a group mapping,
-and it does not represent a user deactivation state. The platform currently has no
-separate reversible ``user_deactivate`` operation in this MCP surface.
-
-The bulk tool materializes the attachment list before changing anything and returns
-removed, already-absent, remaining, and unattempted IDs. ``partial`` means some known
-changes happened but access remains or a deterministic failure stopped the pass;
-``unknown`` means a response or final check could not establish the current state.
+``user_delete`` takes an exact ``user_id`` and performs a hard global deletion. It must
+be called from the parent tenant context with ``confirm=true``. It is not a sandbox-only
+removal, and it does not revoke tenant policy attachments first.
 
 Worked examples
 ---------------
@@ -151,30 +142,31 @@ Create the identity, then grant access in the parent and sandbox independently::
    tenant_use(tenant_name="customer-sb-analysis", confirm=true)
    user_grant_policy(user_id="auth0|...", policy_id="agp-datagrid-administrator", confirm=true)
 
-Remove only the sandbox's direct access; the parent attachment is unchanged::
+Remove only the sandbox's direct policy; the parent attachment is unchanged::
 
-   user_revoke_all_policies(user_id="auth0|...", confirm=true)
-   # => {"result": "ok", "scope": "selected_tenant", "changed": true, ...}
+   user_revoke_policy(
+     user_id="auth0|...",
+     policy_id="agp-datagrid-administrator",
+     confirm=true
+   )
+   # => {"result": "ok", "changed": true, ...}
 
-For a complete offboarding, run direct cleanup in each tenant first when possible, then
-delete the global identity from the parent context::
+Delete the global identity from the parent context::
 
    tenant_use(tenant_name="customer", confirm=true)
-   user_revoke_all_policies(user_id="auth0|...", confirm=true)
    user_delete(user_id="auth0|...", confirm=true)
    # => {"result": "ok", "scope": "global", "changed": true}
 
 Close cases:
 
-* ``user_revoke_all_policies`` returning ``changed=false`` means no active direct
-  attachment changed. It does not prove that group-mapped access is absent.
-* ``user_delete`` returning ``unknown`` is not a failure you should replay as a second
-  delete. The identity may already be gone while backend cleanup or event publication
-  remains unverified.
-* A ``partial`` bulk result is actionable: use ``remaining_attachment_ids`` to inspect
-  what still grants direct access. ``user_delete`` and direct-policy cleanup are separate
-  operations, so deleting the identity does not make a partial tenant cleanup result
-  disappear from the audit trail.
+* ``user_create`` creates the login identity but does not grant tenant access; call
+  ``user_grant_policy`` separately for each tenant that should be accessible.
+* ``user_revoke_policy`` removes one direct attachment only. Other direct policies and
+  group-mapped access are unchanged.
+* ``user_delete`` is global and irreversible. It does not detach policies first, so use
+  ``user_revoke_policy`` for reversible access removal.
+* Mutation tools use exact IDs, not a display name or email lookup. List first when the
+  identity or policy ID is not already known.
 
 
 .. _mcp-tool-databases:

--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -80,6 +80,34 @@ Manage which Amperity tenant the current session targets, and read session-level
      - **feedback_submit**
 
 
+.. _mcp-tool-users-access:
+
+Users and access
+==================================================
+
+Find and create global Amperity users, inspect policies, and manage a user's direct unscoped policy attachments in the current tenant.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Description
+     - Tools
+
+   * - Find and create users
+     - **user_list**
+
+       **user_create**
+
+   * - Inspect policies
+     - **policy_list**
+
+   * - Grant and revoke direct unscoped policies
+     - **user_grant_policy**
+
+       **user_revoke_policy**
+
+
 .. _mcp-tool-databases:
 
 Databases and tables


### PR DESCRIPTION
**Customer impact:** Documents the complete six-tool AMP-29 workflow and the platform concepts reviewers/operators need to use it safely: global identities, tenant-scoped direct policy access, invitation control, sandbox context, access removal, and irreversible global deletion.

## Why this PR exists

AMP-29 asks for end-to-end sandbox user provisioning without manual UI work. The implementation reuses Amperity's existing user and policy APIs, but its platform-native shape differs from the ticket's illustrative combined signatures: identity creation is global, access is represented by tenant-scoped policy attachments, and existing `tenant_use` selects the target tenant. These docs explain that translation and give copyable provisioning/offboarding flows.

## Linear expectation mapping

| AMP-29 expectation | Documented workflow |
|---|---|
| `user_list(tenant_id)` | Select the tenant with `tenant_use`, then call `user_list`; results are identities with access in that tenant |
| `user_create(..., role, send_invitation=false)` | Call `user_create` with invitation control, then discover and attach the exact policy separately |
| `user_update_role(...)` | Use `user_grant_policy` and `user_revoke_policy` for exact direct policy attachments |
| Main-tenant Operator + sandbox Admin | Switch context between parent and sandbox, discover each policy ID, and grant each attachment explicitly |
| `user_delete(email, tenant_id)` | Resolve the immutable user ID, return to confirmed parent context, and call `user_delete`; deletion is global |
| Complete automation | Worked examples cover list → create → policy discovery → grant → revoke → delete |

## Implementation mapping

- CLI wrappers over existing admin APIs: [amperity/app#71776](https://github.com/amperity/app/pull/71776)
- Discovery and provisioning (`user_list`, `policy_list`, `user_create`, `user_grant_policy`): [amperity/app#71777](https://github.com/amperity/app/pull/71777)
- Access removal and deletion (`user_revoke_policy`, `user_delete`): [amperity/app#71778](https://github.com/amperity/app/pull/71778)

The app changes remain confined to `service/mcp/mcp-service/**`; no user/auth backend API is introduced. This documentation is not deployment evidence and should land with the final reviewed tool surface.

## Safety and close cases covered

- A global identity is one account shared across tenant contexts; creating it does not itself grant tenant access.
- A direct policy is one explicit user-to-policy attachment. Revoking it does not remove other direct policies or group-mapped access.
- `policy_list` reports the backend's assignable decision; callers should not guess policy IDs from names.
- Mutations use exact user/policy IDs and the selected tenant rather than fuzzy email deletion or arbitrary tenant routing.
- Invitation sending has a stronger gate than silent creation.
- Global deletion always requires confirmed parent context and `confirm=true`; it does not silently bulk-revoke access first.

## Verification

- Head: `6bb4cc0556d27ecc7e42a27cd9b9997b46ad89e0` (89 additions, 1 file).
- Strict local Sphinx API build (`-W`): passed.
- CircleCI `docs-test`: passed on the same head.

[AMP-29]: https://linear.app/amperity/issue/AMP-29/mcp-missing-user-provisioning-and-role-management-tools
