### PR TITLE
Add ai_system_prompt_get to MCP tool catalog

### DIFF
--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -613,6 +613,9 @@ Manage segments and folders.
 
        **context_documents_create**
 
+   * - Read the tenant's AmpAI system prompt
+     - **ai_system_prompt_get**
+
 
 .. _mcp-tool-labels:
 


### PR DESCRIPTION
## Summary

Mirrors the new `ai_system_prompt_get` MCP tool into the public catalog. It was added to `EXTERNAL_TOOLS` in [amperity/app#71499](https://github.com/amperity/app/pull/71499), which exposes it to hosted MCP clients — this page must list exactly the externally-exposed tool set (per `service/mcp/mcp-service/docs/adding-a-tool.md`).

## Changes

- `amperity_api/source/mcp_tool_reference.rst` — new row in the "Manage company context documents" table for `ai_system_prompt_get`, describing it as reading the tenant's AmpAI system prompt.