### PR TITLE
Match the profile store stats response to the shipped snake_case keys

### DIFF
--- a/amperity_api/source/endpoint_get_profile_store_stats.rst
+++ b/amperity_api/source/endpoint_get_profile_store_stats.rst
@@ -152,8 +152,8 @@ The **200** response returns statistics for the profile collection.
    :linenos:
 
    {
-     "total-profiles": 0,
-     "link-cardinality": {
+     "total_profiles": 0,
+     "link_cardinality": {
        "email": 0,
        "phone": 0
      }
@@ -178,10 +178,10 @@ A **200 OK** response contains the following parameters.
    * - Parameter
      - Description
 
-   * - **total-profiles**
+   * - **total_profiles**
      - The total number of profiles in the profile collection.
 
-   * - **link-cardinality**
+   * - **link_cardinality**
      - A map of keychain link type to the number of indexed link values for that type.
 
 .. endpoint-get-profile-store-stats-response-parameters-end


### PR DESCRIPTION
## Summary

`GET /collections/{collection-id}/stats` in `real-time-api` returns `total_profiles` and `link_cardinality`. The published docs still showed the hyphenated keyword names the handler used before the rename, in both the 200 example block and the response-parameter table.

The rename shipped in amperity/app#71456 (merged Aug 3). Nothing in the system accepts the hyphenated keys anymore, so a customer coding against `total-profiles` from this page gets nothing back and no hint why.

## Changes

`amperity_api/source/endpoint_get_profile_store_stats.rst`: `total-profiles` to `total_profiles` and `link-cardinality` to `link_cardinality`, in the 200 example and the parameter table. No other page in the repo references either key.

## Business Impact

Corrects published API documentation for a shipped response-shape change, preventing integration failures for customers building against the profile store stats endpoint.