### PR TITLE
Sync Bloomreach connector docs to Tracking API batch overhaul

### DIFF
--- a/amperity_modals/source/destination-bloomreach.rst
+++ b/amperity_modals/source/destination-bloomreach.rst
@@ -80,12 +80,6 @@ Settings
    :start-after: .. setting-common-business-user-access-restrict-pii-start
    :end-before: .. setting-common-business-user-access-restrict-pii-end
 
-**Import name**
-
-.. include:: ../../shared/destination_settings.rst
-   :start-after: .. setting-bloomreach-import-name-start
-   :end-before: .. setting-bloomreach-import-name-end
-
 **Bloomreach identifier**
 
 .. include:: ../../shared/destination_settings.rst

--- a/amperity_operator/source/campaign_bloomreach.rst
+++ b/amperity_operator/source/campaign_bloomreach.rst
@@ -55,20 +55,16 @@ This destination uses the `Bloomreach Engagement API <https://documentation.bloo
 .. campaign-bloomreach-api-note-end
 
 .. include:: destination_bloomreach.rst
-   :start-after: .. destination-bloomreach-import-replace-start
-   :end-before: .. destination-bloomreach-import-replace-end
-
-.. include:: destination_bloomreach.rst
-   :start-after: .. destination-bloomreach-import-limit-start
-   :end-before: .. destination-bloomreach-import-limit-end
+   :start-after: .. destination-bloomreach-membership-start
+   :end-before: .. destination-bloomreach-membership-end
 
 .. include:: destination_bloomreach.rst
    :start-after: .. destination-bloomreach-attribute-limit-start
    :end-before: .. destination-bloomreach-attribute-limit-end
 
 .. include:: destination_bloomreach.rst
-   :start-after: .. destination-bloomreach-async-start
-   :end-before: .. destination-bloomreach-async-end
+   :start-after: .. destination-bloomreach-reporting-start
+   :end-before: .. destination-bloomreach-reporting-end
 
 
 .. _campaign-bloomreach-get-details:
@@ -135,14 +131,6 @@ Get details
           :align: center
           :class: no-scaled-link
      - **Required configuration settings**
-
-       **Import name**
-
-          |checkmark-required| **Required**
-
-          .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-bloomreach-import-name-start
-             :end-before: .. setting-bloomreach-import-name-end
 
        **Bloomreach identifier**
 
@@ -344,12 +332,6 @@ Add destination
           .. include:: ../../shared/destination_settings.rst
              :start-after: .. campaigns-steps-campaign-settings-start
              :end-before: .. campaigns-steps-campaign-settings-end
-
-       **Import name**
-
-          .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-bloomreach-import-name-start
-             :end-before: .. setting-bloomreach-import-name-end
 
        **Bloomreach identifier**
 

--- a/amperity_operator/source/destination_bloomreach.rst
+++ b/amperity_operator/source/destination_bloomreach.rst
@@ -54,31 +54,25 @@ This destination uses the `Bloomreach Engagement API <https://documentation.bloo
 
 .. destination-bloomreach-api-note-end
 
-.. destination-bloomreach-import-replace-start
+.. destination-bloomreach-membership-start
 
-.. important:: New imports replace existing imports in |destination-name| that have the same import name. Use a unique import name for each orchestration or campaign to avoid overwriting data unintentionally.
+.. important:: |destination-name| has no API for setting segment membership directly. Amperity records membership as ``segment-addition`` and ``segment-deletion`` events that carry the segment name. To act on this membership in |destination-name|--for example, to target it in a campaign--build a segmentation in your |destination-name| project over these events. Until that segmentation exists, the membership data is present in |destination-name| but is not yet usable as a segment.
 
-.. destination-bloomreach-import-replace-end
-
-.. destination-bloomreach-import-limit-start
-
-.. caution:: Bloomreach limits each project to 25 active import definitions. When the limit is reached, Amperity automatically deletes the oldest Amperity-created import to make room for the new one. If all 25 imports were created outside of Amperity, the send will fail with a message asking the user to delete unused imports in Bloomreach to free a slot.
-
-.. destination-bloomreach-import-limit-end
+.. destination-bloomreach-membership-end
 
 .. destination-bloomreach-attribute-limit-start
 
-.. caution:: Bloomreach allows at most 255 attributes per customer. The connector adds a segment-membership attribute to every customer, so a single orchestration or campaign can send at most 254 attributes. A send with more than 254 attributes fails with an error before any data is sent.
+.. caution:: |destination-name| allows at most 255 attributes per customer. An orchestration or campaign that sends more than 255 attributes fails with an error before any data is sent.
 
 .. destination-bloomreach-attribute-limit-end
 
-.. destination-bloomreach-async-start
+.. destination-bloomreach-reporting-start
 
-.. note:: |destination-name| processes imports asynchronously after Amperity sends the data. Amperity reports rows as succeeded once the import is triggered. There is no import status tracking. To confirm a send or troubleshoot missing customer data, check the import in the |destination-name| dashboard.
+.. note:: Amperity sends customer updates and segment membership changes to |destination-name| over the batch API and receives a result for each row in the same request. Rows that |destination-name| rejects are reported as failed, and the rejection reason is recorded as an error on the orchestration or campaign run.
 
-.. warning:: Attributes accumulate across all imports in a Bloomreach project. If a project exceeds 255 attributes, Bloomreach discards the over-limit import; Amperity does not track this cumulative total, so the failure appears only in the |destination-name| dashboard.
+.. warning:: Attributes accumulate across everything sent to a |destination-name| project over time. If the project's total number of distinct attributes would exceed |destination-name|'s limit of 255, |destination-name| rejects the over-limit writes and Amperity reports them as errors on the run.
 
-.. destination-bloomreach-async-end
+.. destination-bloomreach-reporting-end
 
 
 .. _destination-bloomreach-get-details:
@@ -145,14 +139,6 @@ Get details
           :align: center
           :class: no-scaled-link
      - **Required configuration settings**
-
-       **Import name**
-
-          |checkmark-required| **Required**
-
-          .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-bloomreach-import-name-start
-             :end-before: .. setting-bloomreach-import-name-end
 
        **Bloomreach identifier**
 
@@ -348,12 +334,6 @@ Add destination
      - .. include:: ../../shared/destination_settings.rst
           :start-after: .. destinations-steps-settings-start
           :end-before: .. destinations-steps-settings-end
-
-       **Import name**
-
-          .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-bloomreach-import-name-start
-             :end-before: .. setting-bloomreach-import-name-end
 
        **Bloomreach identifier**
 

--- a/amperity_user/source/campaign_bloomreach.rst
+++ b/amperity_user/source/campaign_bloomreach.rst
@@ -39,6 +39,10 @@ Send audiences to Bloomreach
    :start-after: .. destination-bloomreach-api-note-start
    :end-before: .. destination-bloomreach-api-note-end
 
+.. include:: ../../amperity_operator/source/destination_bloomreach.rst
+   :start-after: .. destination-bloomreach-membership-start
+   :end-before: .. destination-bloomreach-membership-end
+
 .. include:: ../../shared/channels.rst
    :start-after: .. channels-overview-list-intro-start
    :end-before: .. channels-overview-list-intro-end
@@ -69,7 +73,7 @@ Build a segment
 
 .. channel-bloomreach-build-segment-important-start
 
-.. important:: The segment you build must include an attribute named to match the **Bloomreach identifier** selected for the destination, such as email, external ID, cookie, or Google Analytics ID. If no attribute matches, the campaign fails with an error before any data is sent. All other attributes in your segment are sent as customer properties to |destination-name|. Rows with blank values in the identity column are skipped.
+.. important:: The segment you build must include an attribute named to match the **Bloomreach identifier** selected for the destination, such as email, external ID, cookie, or Google Analytics ID. If no attribute matches, the campaign fails with an error before any data is sent. All other attributes in your segment are sent as customer properties to |destination-name|. Rows with blank values in the identity column are skipped, counted as failed rows, and reported as an error on the run.
 
 .. channel-bloomreach-build-segment-important-end
 
@@ -135,8 +139,8 @@ Add to a campaign
 .. channel-bloomreach-build-campaign-steps-end
 
 .. include:: ../../amperity_operator/source/destination_bloomreach.rst
-   :start-after: .. destination-bloomreach-async-start
-   :end-before: .. destination-bloomreach-async-end
+   :start-after: .. destination-bloomreach-reporting-start
+   :end-before: .. destination-bloomreach-reporting-end
 
 
 .. _channel-bloomreach-configure-default-attributes:

--- a/amperity_user/source/destination_bloomreach.rst
+++ b/amperity_user/source/destination_bloomreach.rst
@@ -37,6 +37,10 @@ Send query results to Bloomreach
    :start-after: .. destination-bloomreach-api-note-start
    :end-before: .. destination-bloomreach-api-note-end
 
+.. include:: ../../amperity_operator/source/destination_bloomreach.rst
+   :start-after: .. destination-bloomreach-membership-start
+   :end-before: .. destination-bloomreach-membership-end
+
 .. include:: ../../shared/destinations.rst
    :start-after: .. destinations-overview-list-intro-start
    :end-before: .. destinations-overview-list-intro-end
@@ -127,7 +131,7 @@ You can also use the Amperity ID as an external identifier:
 
 .. sendto-bloomreach-build-query-important-start
 
-.. important:: Your query results must include a column named to match the **Bloomreach identifier** selected for the destination (for example, a column named ``email`` when the identifier is **email**). If no column matches, the orchestration fails with an error before any data is sent. Rows with blank values in the identity column are skipped.
+.. important:: Your query results must include a column named to match the **Bloomreach identifier** selected for the destination (for example, a column named ``email`` when the identifier is **email**). If no column matches, the orchestration fails with an error before any data is sent. Rows with blank values in the identity column are skipped, counted as failed rows, and reported as an error on the run.
 
 .. sendto-bloomreach-build-query-important-end
 
@@ -166,5 +170,5 @@ Run orchestration
    :end-before: .. sendtos-run-orchestration-steps-end
 
 .. include:: ../../amperity_operator/source/destination_bloomreach.rst
-   :start-after: .. destination-bloomreach-async-start
-   :end-before: .. destination-bloomreach-async-end
+   :start-after: .. destination-bloomreach-reporting-start
+   :end-before: .. destination-bloomreach-reporting-end

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -32,7 +32,7 @@ The public API key ID for your Bloomreach Engagement project.
 
 .. credential-bloomreach-api-secret-start
 
-The private API secret for your Bloomreach Engagement project. The API key must have the "Imports > Allow to Create new Imports" permission enabled.
+The private API secret for your Bloomreach Engagement project. The API key's API group must permit customer updates and event tracking.
 
 .. credential-bloomreach-api-secret-end
 

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -9,13 +9,6 @@
 
 .. TODO: Placeholder content for testing and validation.
 
-.. setting-bloomreach-import-name-start
-
-The name of the import definition that will be created in Bloomreach Engagement. Amperity manages import definitions with this name.
-
-.. setting-bloomreach-import-name-end
-
-
 .. setting-bloomreach-identity-column-start
 
 The Bloomreach hard identifier to use as the primary key. Options include **email**, **cookie**, **google_analytics**, or **external_id**. Map a dataset attribute to a destination attribute with the same name as the identifier you select. If no dataset attribute matches, the run fails with an error before any data is sent.
@@ -25,7 +18,7 @@ The Bloomreach hard identifier to use as the primary key. Options include **emai
 
 .. setting-bloomreach-segment-name-start
 
-A name for the segment being sent to Bloomreach. Every customer sent through this destination is tagged in Bloomreach with a boolean **Is <segment name> member?** attribute set to true.
+A name for the segment sent to Bloomreach. When a customer's membership changes, Amperity records a segment membership event in Bloomreach--``segment-addition`` when a customer enters the audience and ``segment-deletion`` when a customer leaves it--with this name stored as the event's ``segment_name`` property.
 
 .. setting-bloomreach-segment-name-end
 


### PR DESCRIPTION
Bloomreach was rewritten to send customer attributes and segment membership over the Tracking API batch endpoint instead of the Imports API (app PR #71605, INT-52). Update the docs to match /app/:

- Remove the "Import name" setting (no longer exists; only Bloomreach identifier and Segment name remain) and delete the shared snippet plus every include of it.
- Drop the import-replace and 25-import-definition-cap notes; imports and the cap are gone.
- Rewrite the async/fire-and-forget note: the batch endpoint returns a per-row result in the same request, and rejected rows now surface as errors on the run (no "check the Bloomreach dashboard").
- Attribute limit is 255 by default; membership is recorded as an event (segment-addition / segment-deletion carrying segment_name), not a per-customer attribute, so drop the 254 case. Reword the cumulative 255-per-project accumulation warning to describe rejected commands.
- Fix the API secret permission: the key's API group must permit customer updates and event tracking (was "Imports > Allow to Create new Imports").
- Note that blank identity rows are skipped AND counted as failed with an error on the run.
- Add an admonition that Bloomreach has no API to set membership directly; a segmentation must be built over the membership events before the audience is usable.

Verified with strict (-W) Sphinx builds of the operator, user, and modals books.