### PR TITLE
Sevenrooms connector 65476

### DIFF
--- a/amperity_base/source/_templates/destinations.html
+++ b/amperity_base/source/_templates/destinations.html
@@ -1591,6 +1591,21 @@
       </div>
     </a>
 
+    <a href="/operator/destination_sevenrooms.html" class="card">
+      <div class="card-content" title="SevenRooms">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-sevenrooms.png" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-sevenrooms-dark.png" class="card-image" />
+        </figure>
+        <div class="card-title">SevenRooms</div>
+        <div class="card-description">
+          Send audiences to SevenRooms as client tags.
+        </div>
+      </div>
+    </a>
+
     <a href="/operator/destination_sftp.html" class="card">
       <div class="card-content" title="SFTP">
         <figure class="light-only align-center">

--- a/amperity_base/source/_templates/sources.html
+++ b/amperity_base/source/_templates/sources.html
@@ -954,6 +954,22 @@
     </a>
 
 
+    <a href="/operator/source_sevenrooms.html" class="card">
+      <div class="card-content" title="SevenRooms">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-sevenrooms.png" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-sevenrooms-dark.png" class="card-image" />
+        </figure>
+        <div class="card-title">SevenRooms</div>
+        <div class="card-description">
+          Pull reservation and guest data from SevenRooms.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/source_sftp.html" class="card">
       <div class="card-content" title="SFTP">
         <figure class="light-only align-center">

--- a/amperity_modals/source/destination-sevenrooms.rst
+++ b/amperity_modals/source/destination-sevenrooms.rst
@@ -88,14 +88,14 @@ Settings
    :start-after: .. setting-common-audience-primary-key-start
    :end-before: .. setting-common-audience-primary-key-end
 
-**Campaign file settings**
-
-.. include:: ../../shared/destination_settings.rst
-   :start-after: .. campaigns-steps-campaign-settings-start
-   :end-before: .. campaigns-steps-campaign-settings-end
-
 **Tag name**
 
 .. include:: ../../shared/destination_settings.rst
    :start-after: .. setting-sevenrooms-tag-name-start
    :end-before: .. setting-sevenrooms-tag-name-end
+
+**Campaign file settings**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. campaigns-steps-campaign-settings-start
+   :end-before: .. campaigns-steps-campaign-settings-end

--- a/amperity_modals/source/destination-sevenrooms.rst
+++ b/amperity_modals/source/destination-sevenrooms.rst
@@ -1,0 +1,101 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: SevenRooms
+.. |audience-primary-key| replace:: "email"
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+
+
+SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. destination-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-sevenrooms-beta-end
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**Client ID**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-sevenrooms-client-id-start
+   :end-before: .. credential-sevenrooms-client-id-end
+
+**Client Secret**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-sevenrooms-client-secret-start
+   :end-before: .. credential-sevenrooms-client-secret-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Base URL**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-sevenrooms-base-url-start
+   :end-before: .. setting-sevenrooms-base-url-end
+
+**Venue Group ID**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-sevenrooms-venue-group-id-start
+   :end-before: .. setting-sevenrooms-venue-group-id-end
+
+**Tag group**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-sevenrooms-tag-group-start
+   :end-before: .. setting-sevenrooms-tag-group-end
+
+**Audience primary key**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-audience-primary-key-start
+   :end-before: .. setting-common-audience-primary-key-end
+
+**Campaign file settings**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. campaigns-steps-campaign-settings-start
+   :end-before: .. campaigns-steps-campaign-settings-end
+
+**Tag name**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-sevenrooms-tag-name-start
+   :end-before: .. setting-sevenrooms-tag-name-end

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -92,6 +92,7 @@ Site Index
    destination-salesforce
    destination-salesforce-marketing-cloud
    destination-sendgrid
+   destination-sevenrooms
    destination-sfmc-sftp
    destination-sftp
    destination-smg

--- a/amperity_operator/source/campaign_sevenrooms.rst
+++ b/amperity_operator/source/campaign_sevenrooms.rst
@@ -1,0 +1,380 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: SevenRooms
+.. |destination-api| replace:: SevenRooms API
+.. |plugin-name| replace:: "SevenRooms"
+.. |credential-type| replace:: "sevenrooms"
+.. |required-credentials| replace:: "Client ID and Client Secret"
+.. |audience-primary-key| replace:: "email"
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+.. |filter-the-list| replace:: "Seven"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send campaigns to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send campaigns to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure campaigns for SevenRooms
+
+==================================================
+Configure campaigns for SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. campaign-sevenrooms-start
+
+Use Amperity to activate an audience into |destination-name|. Build a campaign that includes the **email** field, and then send it to |destination-name|.
+
+SevenRooms builds its guest segments from client tags, so Amperity activates an audience as a named client tag applied to matching guest profiles. Amperity matches guest profiles by email, applies the tag to members of the audience, and removes the tag from guest profiles that leave the audience. Amperity also writes profile attributes -- such as phone number, first name, and last name -- onto the matching guest profiles. Each run sends only the additions, removals, and attribute changes since the previous run, not the full audience.
+
+A SevenRooms client tag is addressed as ``group:tag``. The **Tag group** is set once per destination and the **Tag name** identifies the audience; together they form the tag that Amperity applies. Changing either one sends the entire audience again under the new tag.
+
+.. campaign-sevenrooms-end
+
+.. campaign-sevenrooms-api-note-start
+
+.. note:: This destination uses the `SevenRooms API <https://api-docs.sevenrooms.com>`__ |ext_link|.
+
+.. campaign-sevenrooms-api-note-end
+
+.. campaign-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. campaign-sevenrooms-beta-end
+
+.. campaign-sevenrooms-existing-clients-start
+
+.. note:: SevenRooms must already contain a guest profile that matches an audience member's email within the venue group. Amperity applies tags and writes attributes to guest profiles that already exist; an audience member that SevenRooms cannot match is reported as a failed row.
+
+.. campaign-sevenrooms-existing-clients-end
+
+.. campaign-sevenrooms-partial-failure-start
+
+.. caution:: A run can partially succeed. Individual audience members that SevenRooms rejects -- for example, a member with no matching guest profile or a field value that is not valid for a guest profile -- are counted as failed rows while the rest of the run completes.
+
+.. campaign-sevenrooms-partial-failure-end
+
+.. campaign-sevenrooms-limits-start
+
+.. note:: Amperity sends one request per audience member, at a conservative rate of approximately 10 requests per second. This rate is an Amperity-side limit, not a published |destination-api| limit.
+
+.. campaign-sevenrooms-limits-end
+
+
+.. _campaign-sevenrooms-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. campaign-sevenrooms-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **Client ID and Client Secret**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-id-start
+             :end-before: .. credential-sevenrooms-client-id-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-secret-start
+             :end-before: .. credential-sevenrooms-client-secret-end
+
+       .. tip::
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-find-credentials-start
+             :end-before: .. credential-sevenrooms-find-credentials-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Base URL**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-base-url-start
+             :end-before: .. setting-sevenrooms-base-url-end
+
+       **Venue Group ID**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-venue-group-id-start
+             :end-before: .. setting-sevenrooms-venue-group-id-end
+
+       **Tag group**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-group-start
+             :end-before: .. setting-sevenrooms-tag-group-end
+
+       **Audience primary key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Tag name**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-name-start
+             :end-before: .. setting-sevenrooms-tag-name-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - A campaign that outputs the **email** field and any profile attributes to send to the |destination-name| audience.
+
+.. campaign-sevenrooms-get-details-end
+
+
+.. _campaign-sevenrooms-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for SevenRooms**
+
+.. campaign-sevenrooms-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **Client ID and Client Secret**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-id-start
+             :end-before: .. credential-sevenrooms-client-id-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-secret-start
+             :end-before: .. credential-sevenrooms-client-secret-end
+
+.. campaign-sevenrooms-credentials-steps-end
+
+
+.. _campaign-sevenrooms-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for SevenRooms**
+
+.. campaign-sevenrooms-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-add-destinations-start
+          :end-before: .. campaigns-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-add-destinations-select-start
+          :end-before: .. campaigns-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-select-credential-start
+          :end-before: .. campaigns-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. campaigns-steps-test-connection-start
+             :end-before: .. campaigns-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-name-and-description-start
+          :end-before: .. campaigns-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-settings-start
+          :end-before: .. campaigns-steps-settings-end
+
+       **Base URL**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-base-url-start
+             :end-before: .. setting-sevenrooms-base-url-end
+
+       **Venue Group ID**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-venue-group-id-start
+             :end-before: .. setting-sevenrooms-venue-group-id-end
+
+       **Tag group**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-group-start
+             :end-before: .. setting-sevenrooms-tag-group-end
+
+       **Audience primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Campaign file settings**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. campaigns-steps-campaign-settings-start
+             :end-before: .. campaigns-steps-campaign-settings-end
+
+       **Tag name** (Required at orchestration)
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-name-start
+             :end-before: .. setting-sevenrooms-tag-name-end
+
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-business-users-start
+          :end-before: .. campaigns-steps-business-users-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. campaign-sevenrooms-add-steps-end

--- a/amperity_operator/source/destination_sevenrooms.rst
+++ b/amperity_operator/source/destination_sevenrooms.rst
@@ -1,0 +1,374 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: SevenRooms
+.. |destination-api| replace:: SevenRooms API
+.. |plugin-name| replace:: "SevenRooms"
+.. |credential-type| replace:: "sevenrooms"
+.. |required-credentials| replace:: "Client ID and Client Secret"
+.. |audience-primary-key| replace:: "email"
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+.. |filter-the-list| replace:: "Seven"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send audiences to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send audiences to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure destinations for SevenRooms
+
+==================================================
+Configure destinations for SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. destination-sevenrooms-start
+
+Use Amperity to activate an audience into |destination-name|. Build a query or segment that includes the **email** field, and then send it to |destination-name|.
+
+SevenRooms builds its guest segments from client tags, so Amperity activates an audience as a named client tag applied to matching guest profiles. Amperity matches guest profiles by email, applies the tag to members of the audience, and removes the tag from guest profiles that leave the audience. Amperity also writes profile attributes -- such as phone number, first name, and last name -- onto the matching guest profiles. Each run sends only the additions, removals, and attribute changes since the previous run, not the full audience.
+
+A SevenRooms client tag is addressed as ``group:tag``. The **Tag group** is set once per destination and the **Tag name** identifies the audience; together they form the tag that Amperity applies. Changing either one sends the entire audience again under the new tag.
+
+.. destination-sevenrooms-end
+
+.. destination-sevenrooms-api-note-start
+
+.. note:: This destination uses the `SevenRooms API <https://api-docs.sevenrooms.com>`__ |ext_link|.
+
+.. destination-sevenrooms-api-note-end
+
+.. destination-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-sevenrooms-beta-end
+
+.. destination-sevenrooms-existing-clients-start
+
+.. note:: SevenRooms must already contain a guest profile that matches an audience member's email within the venue group. Amperity applies tags and writes attributes to guest profiles that already exist; an audience member that SevenRooms cannot match is reported as a failed row.
+
+.. destination-sevenrooms-existing-clients-end
+
+.. destination-sevenrooms-partial-failure-start
+
+.. caution:: A run can partially succeed. Individual audience members that SevenRooms rejects -- for example, a member with no matching guest profile or a field value that is not valid for a guest profile -- are counted as failed rows while the rest of the run completes.
+
+.. destination-sevenrooms-partial-failure-end
+
+.. destination-sevenrooms-limits-start
+
+.. note:: Amperity sends one request per audience member, at a conservative rate of approximately 10 requests per second. This rate is an Amperity-side limit, not a published |destination-api| limit.
+
+.. destination-sevenrooms-limits-end
+
+
+.. _destination-sevenrooms-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-sevenrooms-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **Client ID and Client Secret**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-id-start
+             :end-before: .. credential-sevenrooms-client-id-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-secret-start
+             :end-before: .. credential-sevenrooms-client-secret-end
+
+       .. tip::
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-find-credentials-start
+             :end-before: .. credential-sevenrooms-find-credentials-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Base URL**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-base-url-start
+             :end-before: .. setting-sevenrooms-base-url-end
+
+       **Venue Group ID**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-venue-group-id-start
+             :end-before: .. setting-sevenrooms-venue-group-id-end
+
+       **Tag group**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-group-start
+             :end-before: .. setting-sevenrooms-tag-group-end
+
+       **Audience primary key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Tag name**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-name-start
+             :end-before: .. setting-sevenrooms-tag-name-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - A query or segment that outputs the **email** field and any profile attributes to send to the |destination-name| audience.
+
+.. destination-sevenrooms-get-details-end
+
+
+.. _destination-sevenrooms-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for SevenRooms**
+
+.. destination-sevenrooms-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **Client ID and Client Secret**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-id-start
+             :end-before: .. credential-sevenrooms-client-id-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-sevenrooms-client-secret-start
+             :end-before: .. credential-sevenrooms-client-secret-end
+
+.. destination-sevenrooms-credentials-steps-end
+
+
+.. _destination-sevenrooms-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for SevenRooms**
+
+.. destination-sevenrooms-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Base URL**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-base-url-start
+             :end-before: .. setting-sevenrooms-base-url-end
+
+       **Venue Group ID**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-venue-group-id-start
+             :end-before: .. setting-sevenrooms-venue-group-id-end
+
+       **Tag group**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-group-start
+             :end-before: .. setting-sevenrooms-tag-group-end
+
+       **Audience primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Tag name** (Required at orchestration)
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-sevenrooms-tag-name-start
+             :end-before: .. setting-sevenrooms-tag-name-end
+
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-start
+          :end-before: .. destinations-steps-business-users-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. destination-sevenrooms-add-steps-end

--- a/amperity_operator/source/grid_campaigns.rst
+++ b/amperity_operator/source/grid_campaigns.rst
@@ -300,6 +300,10 @@ Configure Amperity to send campaigns to any marketing workflow.
       :link-type: doc
       :link: campaign_sendgrid
 
+   .. grid-item-card:: SevenRooms
+      :link-type: doc
+      :link: campaign_sevenrooms
+
    .. grid-item-card:: SFTP
       :link-type: doc
       :link: campaign_sftp
@@ -422,6 +426,7 @@ Configure Amperity to send campaigns to any marketing workflow.
    Salesforce Sales Cloud <campaign_salesforce_sales_cloud>
    SAP Emarsys <campaign_sap_emarsys>
    SendGrid <campaign_sendgrid>
+   SevenRooms <campaign_sevenrooms>
    SFTP <campaign_sftp>
    SMG <campaign_smg>
    Snapchat <campaign_snapchat>

--- a/amperity_operator/source/grid_destinations.rst
+++ b/amperity_operator/source/grid_destinations.rst
@@ -366,6 +366,10 @@ Set up connections to send data from Amperity to other marketing applications, t
       :link-type: doc
       :link: destination_sendgrid
 
+   .. grid-item-card:: SevenRooms
+      :link-type: doc
+      :link: destination_sevenrooms
+
    .. grid-item-card:: SFTP
       :link-type: doc
       :link: destination_sftp
@@ -517,6 +521,7 @@ Set up connections to send data from Amperity to other marketing applications, t
    Salesforce Sales Cloud <destination_salesforce_sales_cloud>
    SAP Emarsys <destination_sap_emarsys>
    SendGrid <destination_sendgrid>
+   SevenRooms <destination_sevenrooms>
    SFTP <destination_sftp>
    SMG <destination_smg>
    Snapchat <destination_snapchat>

--- a/amperity_operator/source/source_sevenrooms.rst
+++ b/amperity_operator/source/source_sevenrooms.rst
@@ -1,0 +1,154 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |source-name| replace:: SevenRooms
+.. |plugin-name| replace:: SevenRooms
+.. |credential-type| replace:: **sevenrooms**
+.. |source-interface| replace:: |source-name|
+.. |what-pull| replace:: guest profiles, reservations, venues, and charges
+.. |credential-fields| replace:: the name of the credential, a description, and the |source-name| Client ID and Client Secret
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to pull data from SevenRooms.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to pull data from SevenRooms.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Pull from SevenRooms
+
+==================================================
+Pull from SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. source-sevenrooms-context-start
+
+|source-name| can send |what-pull| to Amperity. Choose which data streams to pull: **clients** (guest profiles) and **venues** are pulled as full exports, while **reservations** and **charges** are pulled incrementally based on the courier's date range. Amperity creates a feed and domain table for each data stream you select.
+
+.. source-sevenrooms-context-end
+
+.. source-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |source-name| source connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. source-sevenrooms-beta-end
+
+.. source-sevenrooms-steps-to-pull-start
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-overview-list-intro-start
+   :end-before: .. sources-overview-list-intro-end
+
+#. :ref:`Get details <source-sevenrooms-get-details>`
+#. :ref:`Add courier <source-sevenrooms-add-courier>`
+#. :ref:`Run courier <source-sevenrooms-run-courier>`
+#. :ref:`Review feed and domain table <source-sevenrooms-review-data>`
+#. :ref:`Add to courier group <source-sevenrooms-add-to-courier-group>`
+
+.. source-sevenrooms-steps-to-pull-end
+
+
+.. _source-sevenrooms-get-details:
+
+Get details
+==================================================
+
+.. source-sevenrooms-get-details-start
+
+|source-name| requires the following configuration details:
+
+#. The **Client ID** and **Client Secret** for your |source-name| API credentials.
+
+   .. include:: ../../shared/credentials_settings.rst
+      :start-after: .. credential-sevenrooms-find-credentials-start
+      :end-before: .. credential-sevenrooms-find-credentials-end
+
+#. The **Base URL** for the |source-name| API, including the version path. For example: ``https://demo.sevenrooms.com/api-ext/2_2``. Your production base URL differs from the demo URL.
+
+#. The **Venue Group ID** for your |source-name| account. This scopes the data that Amperity pulls.
+
+#. The **Data types** to pull. Select any combination of **clients**, **reservations**, **venues**, and **charges**.
+
+.. tip:: Use |ext_snappass| to securely share configuration details for |source-name| between your company and your Amperity representative.
+
+.. source-sevenrooms-get-details-end
+
+
+.. _source-sevenrooms-add-courier:
+
+Add courier
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-courier-start
+   :end-before: .. term-courier-end
+
+**To add a courier**
+
+.. source-sevenrooms-add-courier-start
+
+#. From the **Sources** page, click **Add Courier**. The **Add Courier** page opens.
+#. Find, and then click the icon for |plugin-name|. The **Add Courier** page opens.
+#. Enter the name of the courier. For example: "|source-name|".
+
+   From the **Credential** field, select an existing credential or select **Create a new credential**.
+
+   To add a credential, enter |credential-fields|. Click **Save**.
+
+   When finished click **Continue**.
+
+#. Enter the **Base URL** and **Venue Group ID** for your |source-name| account.
+#. Under **Data types**, select the data streams to pull: **clients**, **reservations**, **venues**, and **charges**.
+#. Click **Create**.
+
+   Amperity creates a feed and domain table for each selected data type.
+
+.. source-sevenrooms-add-courier-end
+
+
+.. _source-sevenrooms-run-courier:
+
+Run courier manually
+==================================================
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-run-courier-start
+   :end-before: .. sources-run-courier-end
+
+**To run the courier manually**
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-run-courier-steps-start
+   :end-before: .. sources-run-courier-steps-end
+
+
+.. _source-sevenrooms-review-data:
+
+Review feed and domain table
+==================================================
+
+.. source-sevenrooms-review-data-start
+
+After running the |source-name| courier, Amperity creates a feed and domain table for each data type you selected: **clients**, **reservations**, **venues**, and **charges**. You may apply semantic tags to the fields in these tables and you may make each domain table available to Stitch, depending on your use case.
+
+.. source-sevenrooms-review-data-end
+
+
+.. _source-sevenrooms-add-to-courier-group:
+
+Add to courier group
+==================================================
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-add-to-courier-group-steps-start
+   :end-before: .. sources-add-to-courier-group-steps-end

--- a/amperity_operator/source/sources.rst
+++ b/amperity_operator/source/sources.rst
@@ -222,6 +222,10 @@ Set up connections for Amperity to ingest data from other tools and platforms.
       :link-type: doc
       :link: source_salesforce_sales_cloud
 
+   .. grid-item-card:: SevenRooms
+      :link-type: doc
+      :link: source_sevenrooms
+
    .. grid-item-card:: SFTP
       :link-type: doc
       :link: source_sftp
@@ -306,6 +310,7 @@ Set up connections for Amperity to ingest data from other tools and platforms.
    Salesforce Marketing Cloud <source_salesforce_marketing_cloud>
    Salesforce Pardot <source_salesforce_pardot>
    Salesforce Sales Cloud <source_salesforce_sales_cloud>
+   SevenRooms <source_sevenrooms>
    SFTP <source_sftp>
    SMG <source_smg>
    SoundCommerce <source_soundcommerce>

--- a/amperity_user/source/campaign_sevenrooms.rst
+++ b/amperity_user/source/campaign_sevenrooms.rst
@@ -1,0 +1,168 @@
+.. https://docs.amperity.com/user/
+
+
+.. |destination-name| replace:: SevenRooms
+.. |what-send| replace:: email addresses and profile attributes
+.. |what-enable| replace:: guest tagging and segmentation
+.. |attributes-sent| replace:: email address
+
+
+.. meta::
+    :description lang=en:
+        Use segments and campaigns to send audiences from Amperity to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Use segments and campaigns to send audiences from Amperity to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Send audiences to SevenRooms
+
+==================================================
+Send audiences to SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. include:: ../../amperity_operator/source/destination_sevenrooms.rst
+   :start-after: .. destination-sevenrooms-api-note-start
+   :end-before: .. destination-sevenrooms-api-note-end
+
+.. channel-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. channel-sevenrooms-beta-end
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-overview-list-intro-start
+   :end-before: .. channels-overview-list-intro-end
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-overview-note-start
+   :end-before: .. channels-overview-note-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-ask-to-configure-campaigns-start
+   :end-before: .. sendtos-ask-to-configure-campaigns-end
+
+
+.. _channel-sevenrooms-build-segment:
+
+Build a segment
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-build-segment-start
+   :end-before: .. channels-build-segment-end
+
+.. admonition:: How do I send |attributes-sent| to |destination-name|?
+
+   .. include:: ../../shared/channels.rst
+      :start-after: .. channels-build-segment-context-start
+      :end-before: .. channels-build-segment-context-end
+
+.. important::
+
+   .. include:: ../../shared/destination_settings.rst
+      :start-after: .. destinations-steps-validate-audience-start
+      :end-before: .. destinations-steps-validate-audience-end
+
+
+.. _channel-sevenrooms-build-campaign:
+
+Add to a campaign
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-build-campaign-start
+   :end-before: .. channels-build-campaign-end
+
+.. channel-sevenrooms-build-campaign-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step 1.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-open-page-start
+          :end-before: .. channels-build-campaign-steps-open-page-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step 2.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-destinations-start
+          :end-before: .. channels-build-campaign-steps-destinations-end
+
+       .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-destinations-note-start
+          :end-before: .. channels-build-campaign-steps-destinations-note-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step 3.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-edit-attributes-start
+          :end-before: .. channels-build-campaign-steps-edit-attributes-end
+
+       .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-edit-attributes-note-start
+          :end-before: .. channels-build-campaign-steps-edit-attributes-note-end
+
+.. channel-sevenrooms-build-campaign-steps-end
+
+
+.. _channel-sevenrooms-configure-default-attributes:
+
+Configure default attributes
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-configure-default-attributes-start
+   :end-before: .. channels-configure-default-attributes-end
+
+.. channel-sevenrooms-configure-default-attributes-start
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Source attribute
+     - Destination attribute
+   * - **email**
+     - **email**
+
+       *Required*
+
+       The email address used to match the guest profile in |destination-name|.
+   * - **phone_number**
+     - **phone_number**
+
+       The phone number written to the matching guest profile.
+   * - **first_name**
+     - **first_name**
+
+       The first name written to the matching guest profile.
+   * - **last_name**
+     - **last_name**
+
+       The last name written to the matching guest profile.
+
+.. channel-sevenrooms-configure-default-attributes-end

--- a/amperity_user/source/destination_sevenrooms.rst
+++ b/amperity_user/source/destination_sevenrooms.rst
@@ -1,0 +1,100 @@
+.. https://docs.amperity.com/user/
+
+
+.. |destination-name| replace:: SevenRooms
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+
+
+.. meta::
+    :description lang=en:
+        Use orchestrations to send query results from Amperity to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Use orchestrations to send query results from Amperity to SevenRooms.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Send query results to SevenRooms
+
+==================================================
+Send query results to SevenRooms
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-sevenrooms-start
+   :end-before: .. term-sevenrooms-end
+
+.. include:: ../../amperity_operator/source/destination_sevenrooms.rst
+   :start-after: .. destination-sevenrooms-api-note-start
+   :end-before: .. destination-sevenrooms-api-note-end
+
+.. sendto-sevenrooms-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. sendto-sevenrooms-beta-end
+
+.. include:: ../../shared/destinations.rst
+   :start-after: .. destinations-overview-list-intro-start
+   :end-before: .. destinations-overview-list-intro-end
+
+#. :ref:`Build a query <sendto-sevenrooms-build-query>`
+#. :ref:`Add orchestration <sendto-sevenrooms-add-orchestration>`
+#. :ref:`Run orchestration <sendto-sevenrooms-run-orchestration>`
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-ask-to-configure-start
+   :end-before: .. sendtos-ask-to-configure-end
+
+
+.. _sendto-sevenrooms-build-query:
+
+Build query
+==================================================
+
+.. sendto-sevenrooms-build-query-start
+
+You will need to build a query that outputs fields that can be sent to |destination-name|. The following example shows how to return email addresses from the **Customer 360** table:
+
+.. code-block:: sql
+
+   SELECT
+     email
+   FROM Customer_360
+   WHERE email IS NOT NULL
+
+The **email** field is required and is used to match guest profiles in |destination-name|. You may add other profile fields -- such as phone number, first name, and last name -- to the query, and Amperity writes them as attributes on the matching guest profile.
+
+.. sendto-sevenrooms-build-query-end
+
+
+.. _sendto-sevenrooms-add-orchestration:
+
+Add orchestration
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-orchestration-start
+   :end-before: .. term-orchestration-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-add-orchestration-generic-start
+   :end-before: .. sendtos-add-orchestration-generic-end
+
+
+.. _sendto-sevenrooms-run-orchestration:
+
+Run orchestration
+==================================================
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-start
+   :end-before: .. sendtos-run-orchestration-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-steps-start
+   :end-before: .. sendtos-run-orchestration-steps-end

--- a/amperity_user/source/grid_campaigns.rst
+++ b/amperity_user/source/grid_campaigns.rst
@@ -303,6 +303,10 @@ Send campaigns to any of the following marketing applications and workflows.
       :link-type: doc
       :link: campaign_sendgrid
 
+   .. grid-item-card:: SevenRooms
+      :link-type: doc
+      :link: campaign_sevenrooms
+
    .. grid-item-card:: SFTP
       :link-type: doc
       :link: campaign_sftp
@@ -362,6 +366,7 @@ Send campaigns to any of the following marketing applications and workflows.
    Salesforce Marketing Cloud <campaign_salesforce_marketing_cloud>
    SAP Emarsys <campaign_sap_emarsys>
    SendGrid <campaign_sendgrid>
+   SevenRooms <campaign_sevenrooms>
    SFTP <campaign_sftp>
    Snapchat <campaign_snapchat>
    The Trade Desk <campaign_the_trade_desk>

--- a/amperity_user/source/grid_queries.rst
+++ b/amperity_user/source/grid_queries.rst
@@ -321,6 +321,10 @@ Send query results to downstream workflows and to support all of your brand's ma
       :link-type: doc
       :link: destination_sendgrid
 
+   .. grid-item-card:: SevenRooms
+      :link-type: doc
+      :link: destination_sevenrooms
+
    .. grid-item-card:: SFTP
       :link-type: doc
       :link: destination_sftp
@@ -596,6 +600,7 @@ The following examples show using the visual **SQL Editor** to build audiences.
    Salesforce Marketing Cloud <destination_salesforce_marketing_cloud>
    SAP Emarsys <destination_sap_emarsys>
    SendGrid <destination_sendgrid>
+   SevenRooms <destination_sevenrooms>
    SFTP <destination_sftp>
    Snapchat <destination_snapchat>
    Tableau <destination_tableau>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -130,9 +130,21 @@ Create the API key in SendGrid with the required scopes: **Marketing > Contacts*
 
 .. credential-sevenrooms-find-credentials-start
 
-Request API credentials (a client ID and client secret) from SevenRooms. API access must be provisioned for your account before Amperity can pull data.
+Request API credentials (a client ID and client secret) from SevenRooms. API access must be provisioned for your account before Amperity can connect to SevenRooms.
 
 .. credential-sevenrooms-find-credentials-end
+
+.. credential-sevenrooms-client-id-start
+
+The Client ID for your SevenRooms API credential.
+
+.. credential-sevenrooms-client-id-end
+
+.. credential-sevenrooms-client-secret-start
+
+The Client Secret for your SevenRooms API credential.
+
+.. credential-sevenrooms-client-secret-end
 
 .. credential-steps-add-credential-start
 

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -128,6 +128,12 @@ Create the API key in SendGrid with the required scopes: **Marketing > Contacts*
 
 .. credential-sendgrid-api-find-key-end
 
+.. credential-sevenrooms-find-credentials-start
+
+Request API credentials (a client ID and client secret) from SevenRooms. API access must be provisioned for your account before Amperity can pull data.
+
+.. credential-sevenrooms-find-credentials-end
+
 .. credential-steps-add-credential-start
 
 From the **Settings** page, select the **Credentials** tab, and then click the **Add credential** button.

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -2931,6 +2931,30 @@ The name of the SendGrid list to which Amperity will send audience members. Ampe
 
 .. setting-sendgrid-list-name-end
 
+.. setting-sevenrooms-base-url-start
+
+The base URL for the SevenRooms API, including the version path. For example: ``https://demo.sevenrooms.com/api-ext/2_2``. Your production base URL differs from the demo URL.
+
+.. setting-sevenrooms-base-url-end
+
+.. setting-sevenrooms-venue-group-id-start
+
+The venue group ID for your SevenRooms account. This scopes the guest profiles that Amperity tags to a single venue group.
+
+.. setting-sevenrooms-venue-group-id-end
+
+.. setting-sevenrooms-tag-group-start
+
+The SevenRooms client tag group that the audience tag belongs to. SevenRooms addresses a client tag as ``group:tag``; this setting is the group portion and is the same for every audience sent to this destination.
+
+.. setting-sevenrooms-tag-group-end
+
+.. setting-sevenrooms-tag-name-start
+
+The SevenRooms client tag that Amperity applies to audience members. This is the tag portion of the ``group:tag`` value and identifies the audience within SevenRooms. Changing the tag name or the tag group sends the entire audience again under the new tag.
+
+.. setting-sevenrooms-tag-name-end
+
 .. setting-sftp-about-start
 
 Secure File Transfer Protocol (SFTP) is a network protocol that provides file access, file transfer, and file management over any reliable data stream.

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -6183,6 +6183,12 @@ Semi-structured data is not shaped as rows and columns, but still has elements t
 
 .. term-sendgrid-end
 
+.. term-sevenrooms-start
+
+**SevenRooms** is a guest experience and data platform for the hospitality industry. Restaurants, hotels, and other operators use it to manage guest profiles, reservations, and transactions.
+
+.. term-sevenrooms-end
+
 .. term-separation-key-start
 
 A separation key, or "sk", is for deterministic unmatching of records.


### PR DESCRIPTION
## Summary

Documents the SevenRooms **destination/egress** connector as beta. The source/ingress
side shipped earlier on this branch; egress was deferred at the time because `/app/`
showed it as a `work-in-progress?` throwing stub. Egress E2 has since landed
(`work-in-progress? false` + `beta? true`, real `destination.clj`/`api.clj` send and a
deployable egress-job), so it is now documentable as a live beta audience-push
destination.

Amperity activates an audience into SevenRooms as a `group:tag` client tag applied to
matching guest profiles, plus profile attributes, matched by email. Sends are
deltalog-incremental (additions/removals/attribute changes only).

All content is grounded in `/app/` (specification/sevenrooms.cljc, plugin
`destination.clj` / `api.clj`). Modeled on SendGrid (structure) and Listrak (the
static-group + dynamic-tag settings split).

## What's included

- Operator topics: `destination_sevenrooms.rst`, `campaign_sevenrooms.rst`
- User topics: `destination_sevenrooms.rst` (Send query results),
  `campaign_sevenrooms.rst` (Send audiences)
- Modal: `destination-sevenrooms.rst`
- Shared snippets: Client ID/Secret credentials; Base URL, Venue Group ID, Tag group,
  Tag name settings (find-credentials note generalized to serve both directions)
- Registration: operator `grid_destinations` / `grid_campaigns`, user `grid_queries` /
  `grid_campaigns`, modal index, and the `destinations.html` landing card

## Verification

`make operator`, `user`, `modals`, and `base` all build clean with `-W`
(warnings-as-errors).

## Reviewer notes

- **Beta is code-backed but the write path is unverified against a live tenant.** The
  SevenRooms client-write endpoint in `api.clj` is reconstructed — there is no public
  confirmation it exists, and it has never run against a provisioned account. The beta
  label carries this risk; the docs describe observable behavior (partial failure,
  unmatched member = failed row, ~10 rps marked as an Amperity-side limit) but
  deliberately omit the internal "unverified endpoint" reasoning. If live verification
  changes the send (e.g. matching on `client_id` instead of email, or a batch write),
  the "matched by email" prose and the one-request-per-member note will need updating.