### PR TITLE
Braze capi connector 49875

### DIFF
--- a/amperity_modals/source/destination-braze-purchases.rst
+++ b/amperity_modals/source/destination-braze-purchases.rst
@@ -11,13 +11,11 @@ Braze Purchases
 
 Send purchase events to |destination-name| using the Braze REST API. Each row returned by your query is sent as a single Braze purchase object and is matched to a Braze user profile by the identifier you choose.
 
-.. events-braze-purchases-modal-beta-start
+.. caution:: Braze records and bills for every purchase you send as a data point. Amperity sends each row in the query result on every run and does not de-duplicate purchases against previous runs. Bound your query to recent purchases and avoid re-sending rows you have already sent, or Braze counts the revenue more than once.
 
 .. admonition:: Beta
 
    The Braze Purchases connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. events-braze-purchases-modal-beta-end
 
 
 Credentials
@@ -74,5 +72,5 @@ Settings
 **Update existing profiles only?**
 
 .. include:: ../../shared/destination_settings.rst
-   :start-after: .. setting-braze-update-existing-profiles-start
-   :end-before: .. setting-braze-update-existing-profiles-end
+   :start-after: .. setting-braze-purchases-update-existing-only-start
+   :end-before: .. setting-braze-purchases-update-existing-only-end

--- a/amperity_modals/source/destination-braze-purchases.rst
+++ b/amperity_modals/source/destination-braze-purchases.rst
@@ -1,0 +1,78 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: Braze
+.. |what-send| replace:: purchase events
+.. |where-send| replace:: |destination-name|
+
+
+Braze Purchases
+==================================================
+
+Send purchase events to |destination-name| using the Braze REST API. Each row returned by your query is sent as a single Braze purchase object and is matched to a Braze user profile by the identifier you choose.
+
+.. events-braze-purchases-modal-beta-start
+
+.. admonition:: Beta
+
+   The Braze Purchases connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. events-braze-purchases-modal-beta-end
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**REST API key**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-braze-purchases-api-key-start
+   :end-before: .. credential-braze-purchases-api-key-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-braze-purchases-api-find-key-start
+   :end-before: .. credential-braze-purchases-api-find-key-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Instance**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-braze-purchases-instance-start
+   :end-before: .. setting-braze-purchases-instance-end
+
+**User identifier**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-braze-user-identifier-start
+   :end-before: .. setting-braze-user-identifier-end
+
+**Update existing profiles only?**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-braze-update-existing-profiles-start
+   :end-before: .. setting-braze-update-existing-profiles-end

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -34,6 +34,7 @@ Site Index
    destination-blue-core
    destination-braze
    destination-braze-cohorts
+   destination-braze-purchases
    destination-camelot-smm
    destination-cheetah-digital
    destination-cordial

--- a/amperity_operator/source/events_braze_purchases.rst
+++ b/amperity_operator/source/events_braze_purchases.rst
@@ -36,7 +36,7 @@ Send purchase events to |destination-name| using the Braze REST API. Each row re
 
 .. events-braze-purchases-billing-start
 
-.. caution:: Braze records and bills for every purchase you send as a data point. Amperity sends each row in the query result on every run and does not de-duplicate purchases against previous runs. Bound your query to recent purchases and avoid re-sending rows you have already sent, or Braze counts the revenue more than once.
+.. caution:: Braze records and bills for every purchase you send as a data point. Amperity sends each row in the query result on every run and does not de-duplicate purchases against previous runs. Bound your query to recent purchases and avoid re-sending rows you have already sent, or Braze counts the revenue more than once. A row with a **quantity** greater than 100 is sent as more than one purchase object — for example, 250 becomes 100, 100, and 50 — and Braze bills each object as a separate data point.
 
 .. events-braze-purchases-billing-end
 
@@ -111,8 +111,8 @@ Get details
        **Update existing profiles only?**
 
           .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-braze-update-existing-profiles-start
-             :end-before: .. setting-braze-update-existing-profiles-end
+             :start-after: .. setting-braze-purchases-update-existing-only-start
+             :end-before: .. setting-braze-purchases-update-existing-only-end
 
    * - .. image:: ../../images/steps-check-off-black.png
           :width: 60 px
@@ -285,8 +285,8 @@ Add destination
        **Update existing profiles only?**
 
           .. include:: ../../shared/destination_settings.rst
-             :start-after: .. setting-braze-update-existing-profiles-start
-             :end-before: .. setting-braze-update-existing-profiles-end
+             :start-after: .. setting-braze-purchases-update-existing-only-start
+             :end-before: .. setting-braze-purchases-update-existing-only-end
 
    * - .. image:: ../../images/steps-05.png
           :width: 60 px
@@ -316,7 +316,7 @@ Build a query
 
 .. events-braze-purchases-build-query-start
 
-Use a query to build a combination of data — typically from the **Unified Itemized Transactions**, **Unified Transactions**, and **Customer 360** tables — that returns one row per purchase to send to |destination-name|. Each row must include a column for the selected **User identifier** and columns for the purchase's **product_id**, **price**, **currency**, and **purchase_time**. A **quantity** column is optional.
+Use a query to build a combination of data — typically from the **Unified Itemized Transactions** and **Customer 360** tables — that returns one row per purchase to send to |destination-name|. Each row must include a column for the selected **User identifier** and columns for the purchase's **product_id**, **price**, **currency**, and **purchase_time**. A **quantity** column is optional.
 
 .. events-braze-purchases-build-query-end
 
@@ -334,17 +334,21 @@ Bound the query to recent purchases so each orchestration sends new purchases in
    SELECT
      c360.customer_id AS external_id
      ,uit.product_id AS product_id
-     ,(uit.item_revenue / uit.item_quantity) AS price
+     ,uit.unit_revenue AS price
      ,uit.item_quantity AS quantity
-     ,ut.currency AS currency
-     ,ut.order_datetime AS purchase_time
+     ,uit.currency AS currency
+     ,uit.order_datetime AS purchase_time
    FROM Unified_Itemized_Transactions uit
-   JOIN Unified_Transactions ut ON uit.order_id = ut.order_id
-   LEFT JOIN Customer_360 c360 ON ut.amperity_id = c360.amperity_id
-   WHERE ut.order_datetime > (CURRENT_DATE - interval '7' day)
-   AND c360.customer_id IS NOT NULL
+   JOIN Customer_360 c360 ON uit.amperity_id = c360.amperity_id
+   WHERE uit.order_datetime > (CURRENT_DATE - interval '7' day)
+     AND COALESCE(uit.is_return, false) = false
+     AND COALESCE(uit.is_cancellation, false) = false
 
-.. note:: **price** is the price for a single unit. Braze computes revenue as **price** multiplied by **quantity**, so map a per-unit price rather than a line total. When your data has a line total, divide it by the quantity as shown above, or send **quantity** as 1 with the line total as **price**.
+.. note:: This example sends the per-unit **unit_revenue** column as **price**, because Braze computes revenue as **price** multiplied by **quantity** — map a per-unit price rather than a line total. When your data has only a line total, divide it by the quantity and guard against a zero or missing divisor, for example ``line_total / NULLIF(quantity, 0) AS price``, or send **quantity** as 1 with the line total as **price**.
+
+.. note:: The example filters out returns and cancellations so they are not sent as purchases and counted as revenue. A return can also carry a negative **unit_revenue**, which Amperity sends as a negative **price** (validation accepts it), so decide deliberately what to send.
+
+.. note:: Map **currency** to a three-character |ext_iso_4217| alphabetic code, such as ``USD``. Amperity checks each value against the ISO 4217 code list and drops rows whose currency is not on it, so a source column that stores a value like "dollar" or "US Dollar" fails every row.
 
 
 .. _events-braze-purchases-user-identifiers:
@@ -356,11 +360,11 @@ User identifiers
 
 The **User identifier** setting selects how Amperity matches each purchase to a Braze user profile. Choose the identifier your Braze profiles are keyed on — typically the same one the **Braze** connector uses to sync profile attributes — so that purchases land on the right profiles.
 
-* **external_id** — your own customer identifier. The query must return an **external_id** column.
 * **braze_id** — the Braze-assigned user ID. The query must return a **braze_id** column.
+* **external_id** — your own customer identifier. The query must return an **external_id** column.
 * **user_alias** — a Braze user alias, which is a name and label pair. The query must return both an **alias_name** and an **alias_label** column.
 
-A row that does not include the column or columns for the selected identifier is reported as failed. When none of the rows include those columns, the orchestration stops before sending.
+A row whose identifier value is empty is reported as failed. If the query does not return the column or columns for the selected identifier at all, the orchestration fails validation before sending anything.
 
 .. events-braze-purchases-user-identifiers-end
 
@@ -374,12 +378,12 @@ Data validation
 
 Amperity validates each row before sending and drops rows that Braze would reject, so that one invalid row does not cause the rest of a request to be rejected. Dropped rows are reported as failed with the reason. A row is dropped when:
 
-* it does not include the column or columns for the selected **User identifier**.
+* the value for the selected **User identifier** is empty (for **user_alias**, either **alias_name** or **alias_label** is empty).
 * **product_id** is missing or is longer than 255 characters.
 * **currency** is not a valid |ext_iso_4217| alphabetic currency code.
 * **price** is not a number.
 * **purchase_time** is missing or cannot be parsed as a date or timestamp.
-* **quantity** is present but is not a whole number, is less than 1, or is larger than 7,500 (the most units a single row can be split across purchase objects).
+* **quantity** is present but is not a whole number, is less than 1 (including 0), or is larger than 7,500 (the most units Amperity can split one row into).
 
 .. events-braze-purchases-data-validation-end
 
@@ -435,7 +439,7 @@ The following table describes each column Amperity sends to |destination-name| a
      - **time**
      - **Required**
 
-       When the purchase occurred. Accepts a date- or time-typed column, a full |ext_iso_8601| timestamp string, a date-only string, or an epoch-seconds value. The column is named **purchase_time** because **time** is a reserved word in many warehouses.
+       When the purchase occurred. Accepts a date- or time-typed column, a full |ext_iso_8601| timestamp string, a date-only string, or an epoch-seconds value. A string timestamp must include a UTC offset, such as "2026-07-20T10:00:00Z" — a warehouse form without one, such as "2026-07-20 10:00:00", is not accepted and the row is dropped. A date-only string, such as "2026-07-20", is treated as midnight UTC. The column is named **purchase_time** because **time** is a reserved word in many warehouses.
 
    * - **quantity**
      - **quantity**
@@ -511,7 +515,6 @@ Workflow actions
        Amperity provides a series of workflow actions that can help resolve specific issues that may arise with |destination-name|, including:
 
        * :ref:`events-braze-purchases-workflow-actions-invalid-credentials`
-       * :ref:`events-braze-purchases-workflow-actions-invalid-settings`
 
    * - .. image:: ../../images/steps-04.png
           :width: 60 px
@@ -528,7 +531,7 @@ Workflow actions
 
 .. events-braze-purchases-workflow-actions-end
 
-.. note:: If Braze rejects an entire request, the workflow reports the error with Braze's message — review the purchase field values returned by your query. If sends are rate limited, Amperity retries automatically; reduce the volume of purchases sent per orchestration if the limit persists.
+.. note:: Braze can accept a request and still reject individual purchases within it. Those rows are reported as failed with the message Braze returned for each, while the workflow itself succeeds — the state behind "the orchestration succeeded but some rows failed." Amperity lists up to 10 such errors per request, followed by a summary line naming how many more were dropped. If Braze rejects an entire request, the workflow reports the error with Braze's message for the whole request — review the purchase field values returned by your query. If sends are rate limited, Amperity retries automatically; reduce the volume of purchases sent per orchestration if the limit persists.
 
 
 .. _events-braze-purchases-workflow-actions-invalid-credentials:
@@ -536,27 +539,14 @@ Workflow actions
 Invalid credentials
 --------------------------------------------------
 
-.. include:: ../../shared/workflow-actions.rst
-   :start-after: .. workflow-actions-generic-invalid-credentials-start
-   :end-before: .. workflow-actions-generic-invalid-credentials-end
+.. events-braze-purchases-workflow-actions-invalid-credentials-start
 
+|destination-name| rejected the REST API key. Braze returns the same error for a REST API key that is not valid and for a key used against the wrong instance, so verify that the key is still active, has the **users.track** permission, and belongs to the same **Instance** the destination is configured for.
 
-.. _events-braze-purchases-workflow-actions-invalid-settings:
+.. events-braze-purchases-workflow-actions-invalid-credentials-end
 
-Invalid settings
---------------------------------------------------
+To resolve this error, verify the credentials and instance configured for this workflow in Amperity.
 
-.. events-braze-purchases-workflow-actions-invalid-settings-start
-
-The configuration for this workflow has a setting that |destination-name| was unable to accept. Braze returns the same error for a REST API key that is not valid and for a key used against the wrong instance, so verify that the **Instance** matches the instance the REST API key belongs to, and that the key has the **users.track** permission.
-
-.. events-braze-purchases-workflow-actions-invalid-settings-end
-
-.. events-braze-purchases-workflow-actions-invalid-settings-steps-start
-
-To resolve this error, verify the settings configured for this workflow in Amperity.
-
-#. Open the **Destinations** page and review the settings for the |destination-name| destination associated with this workflow. Verify that the **Instance** is correct and that the connected credential's REST API key belongs to that instance and has the **users.track** permission.
+#. Open the **Credentials** page and review the REST API key used with this workflow. Verify that it is still active and has the **users.track** permission.
+#. Open the **Destinations** page and verify that the **Instance** setting for the |destination-name| destination matches the instance the REST API key belongs to.
 #. Return to the workflow action, and then click **Resolve** to retry this workflow.
-
-.. events-braze-purchases-workflow-actions-invalid-settings-steps-end

--- a/amperity_operator/source/events_braze_purchases.rst
+++ b/amperity_operator/source/events_braze_purchases.rst
@@ -1,0 +1,562 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Braze
+.. |plugin-name| replace:: "Braze Purchases"
+.. |credential-type| replace:: "braze-purchases"
+.. |required-credentials| replace:: "REST API key"
+.. |what-send| replace:: purchase events
+.. |where-send| replace:: |destination-name|
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send purchase events to Braze.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send purchase events to Braze.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure purchase events for Braze
+
+==================================================
+Configure purchase events for Braze
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-braze-start
+   :end-before: .. term-braze-end
+
+.. events-braze-purchases-overview-start
+
+Send purchase events to |destination-name| using the Braze REST API. Each row returned by your query is sent as a single Braze purchase object to the `/users/track <https://www.braze.com/docs/api/endpoints/user_data/post_user_track/>`__ |ext_link| endpoint and is matched to a Braze user profile by the identifier you choose. See the `purchase object <https://www.braze.com/docs/api/objects_filters/purchase_object/>`__ |ext_link| reference for more information.
+
+.. events-braze-purchases-overview-end
+
+.. events-braze-purchases-billing-start
+
+.. caution:: Braze records and bills for every purchase you send as a data point. Amperity sends each row in the query result on every run and does not de-duplicate purchases against previous runs. Bound your query to recent purchases and avoid re-sending rows you have already sent, or Braze counts the revenue more than once.
+
+.. events-braze-purchases-billing-end
+
+.. events-braze-purchases-beta-start
+
+.. admonition:: Beta
+
+   The Braze Purchases connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. events-braze-purchases-beta-end
+
+
+.. _events-braze-purchases-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. events-braze-purchases-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **REST API key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-braze-purchases-api-key-start
+             :end-before: .. credential-braze-purchases-api-key-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-braze-purchases-api-find-key-start
+             :end-before: .. credential-braze-purchases-api-find-key-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Braze settings**
+
+       **Instance**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-purchases-instance-start
+             :end-before: .. setting-braze-purchases-instance-end
+
+       **User identifier**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-user-identifier-start
+             :end-before: .. setting-braze-user-identifier-end
+
+          See :ref:`events-braze-purchases-user-identifiers` for the columns each option requires.
+
+       **Update existing profiles only?**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-update-existing-profiles-start
+             :end-before: .. setting-braze-update-existing-profiles-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - **Request properties**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-purchases-query-must-return-start
+             :end-before: .. setting-braze-purchases-query-must-return-end
+
+          See :ref:`events-braze-purchases-fields` for the full list of columns.
+
+.. events-braze-purchases-get-details-table-end
+
+
+.. _events-braze-purchases-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Braze Purchases**
+
+.. events-braze-purchases-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - In the **Credentials settings** dialog box, do the following:
+
+       From the **Plugin** dropdown, select **Braze Purchases**.
+
+       .. note:: Amperity provides more than one Braze connector. Select **Braze Purchases** to send purchase events to the Braze REST API. **Braze** (profile attribute sync) and **Braze Cohorts** (audience membership) are separate connectors.
+
+       Assign the credential a name and description that ensures other users of Amperity can recognize when to use this destination.
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **REST API key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-braze-purchases-api-key-start
+             :end-before: .. credential-braze-purchases-api-key-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-braze-purchases-api-find-key-start
+             :end-before: .. credential-braze-purchases-api-find-key-end
+
+.. events-braze-purchases-credentials-steps-end
+
+
+.. _events-braze-purchases-add-destination:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination**
+
+.. events-braze-purchases-add-destination-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destinations.rst
+          :start-after: .. destinations-add-destination-start
+          :end-before: .. destinations-add-destination-end
+
+       Enter the name of the destination and a description. For example: "|destination-name| purchases" and "Send purchase events to |destination-name|.".
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destinations.rst
+          :start-after: .. destinations-add-credentials-start
+          :end-before: .. destinations-add-credentials-end
+
+       .. include:: ../../shared/destinations.rst
+          :start-after: .. destinations-add-new-or-select-existing-start
+          :end-before: .. destinations-add-new-or-select-existing-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Instance**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-purchases-instance-start
+             :end-before: .. setting-braze-purchases-instance-end
+
+       **User identifier**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-user-identifier-start
+             :end-before: .. setting-braze-user-identifier-end
+
+       **Update existing profiles only?**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-braze-update-existing-profiles-start
+             :end-before: .. setting-braze-update-existing-profiles-end
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-orchestration-only-start
+          :end-before: .. destinations-steps-business-users-orchestration-only-end
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. events-braze-purchases-add-destination-end
+
+
+.. _events-braze-purchases-build-query:
+
+Build a query
+==================================================
+
+.. events-braze-purchases-build-query-start
+
+Use a query to build a combination of data — typically from the **Unified Itemized Transactions**, **Unified Transactions**, and **Customer 360** tables — that returns one row per purchase to send to |destination-name|. Each row must include a column for the selected **User identifier** and columns for the purchase's **product_id**, **price**, **currency**, and **purchase_time**. A **quantity** column is optional.
+
+.. events-braze-purchases-build-query-end
+
+.. events-braze-purchases-build-query-required-start
+
+Review the :ref:`events-braze-purchases-fields` section for the columns your query must and may return, and the :ref:`events-braze-purchases-user-identifiers` section for the columns each identifier option requires.
+
+.. events-braze-purchases-build-query-required-end
+
+Bound the query to recent purchases so each orchestration sends new purchases instead of re-sending purchases you have already sent. A query that returns recent purchases keyed by **external_id** is similar to:
+
+.. code-block:: sql
+   :linenos:
+
+   SELECT
+     c360.customer_id AS external_id
+     ,uit.product_id AS product_id
+     ,(uit.item_revenue / uit.item_quantity) AS price
+     ,uit.item_quantity AS quantity
+     ,ut.currency AS currency
+     ,ut.order_datetime AS purchase_time
+   FROM Unified_Itemized_Transactions uit
+   JOIN Unified_Transactions ut ON uit.order_id = ut.order_id
+   LEFT JOIN Customer_360 c360 ON ut.amperity_id = c360.amperity_id
+   WHERE ut.order_datetime > (CURRENT_DATE - interval '7' day)
+   AND c360.customer_id IS NOT NULL
+
+.. note:: **price** is the price for a single unit. Braze computes revenue as **price** multiplied by **quantity**, so map a per-unit price rather than a line total. When your data has a line total, divide it by the quantity as shown above, or send **quantity** as 1 with the line total as **price**.
+
+
+.. _events-braze-purchases-user-identifiers:
+
+User identifiers
+==================================================
+
+.. events-braze-purchases-user-identifiers-start
+
+The **User identifier** setting selects how Amperity matches each purchase to a Braze user profile. Choose the identifier your Braze profiles are keyed on — typically the same one the **Braze** connector uses to sync profile attributes — so that purchases land on the right profiles.
+
+* **external_id** — your own customer identifier. The query must return an **external_id** column.
+* **braze_id** — the Braze-assigned user ID. The query must return a **braze_id** column.
+* **user_alias** — a Braze user alias, which is a name and label pair. The query must return both an **alias_name** and an **alias_label** column.
+
+A row that does not include the column or columns for the selected identifier is reported as failed. When none of the rows include those columns, the orchestration stops before sending.
+
+.. events-braze-purchases-user-identifiers-end
+
+
+.. _events-braze-purchases-data-validation:
+
+Data validation
+==================================================
+
+.. events-braze-purchases-data-validation-start
+
+Amperity validates each row before sending and drops rows that Braze would reject, so that one invalid row does not cause the rest of a request to be rejected. Dropped rows are reported as failed with the reason. A row is dropped when:
+
+* it does not include the column or columns for the selected **User identifier**.
+* **product_id** is missing or is longer than 255 characters.
+* **currency** is not a valid |ext_iso_4217| alphabetic currency code.
+* **price** is not a number.
+* **purchase_time** is missing or cannot be parsed as a date or timestamp.
+* **quantity** is present but is not a whole number, is less than 1, or is larger than 7,500 (the most units a single row can be split across purchase objects).
+
+.. events-braze-purchases-data-validation-end
+
+
+.. _events-braze-purchases-fields:
+
+Purchase object fields
+==================================================
+
+.. events-braze-purchases-fields-start
+
+The following table describes each column Amperity sends to |destination-name| as part of a `purchase object <https://www.braze.com/docs/api/objects_filters/purchase_object/>`__ |ext_link|. A query must return columns with the same name as listed in the "Amperity name" column; Amperity maps them to the Braze purchase object automatically.
+
+.. important::
+
+   .. include:: ../../shared/destination_settings.rst
+      :start-after: .. setting-braze-purchases-query-must-return-start
+      :end-before: .. setting-braze-purchases-query-must-return-end
+
+.. list-table::
+   :widths: 22 20 58
+   :header-rows: 1
+
+   * - Amperity name
+     - Braze field
+     - Description
+
+   * - Identifier column(s)
+     - **external_id**, **braze_id**, or **user_alias**
+     - **Required**
+
+       The column or columns for the selected **User identifier**: an **external_id** column, a **braze_id** column, or an **alias_name** and **alias_label** pair. See :ref:`events-braze-purchases-user-identifiers`.
+
+   * - **product_id**
+     - **product_id**
+     - **Required**
+
+       An identifier for the purchase, such as a product name or product category. Maximum 255 characters. Braze shows up to 5,000 distinct values, so a product name or category is more useful than a SKU.
+
+   * - **price**
+     - **price**
+     - **Required**
+
+       The price for a single unit, as a number. Braze computes revenue as **price** multiplied by **quantity**.
+
+   * - **currency**
+     - **currency**
+     - **Required**
+
+       A three-character |ext_iso_4217| alphabetic currency code. For example: "USD".
+
+   * - **purchase_time**
+     - **time**
+     - **Required**
+
+       When the purchase occurred. Accepts a date- or time-typed column, a full |ext_iso_8601| timestamp string, a date-only string, or an epoch-seconds value. The column is named **purchase_time** because **time** is a reserved word in many warehouses.
+
+   * - **quantity**
+     - **quantity**
+     - **Optional**
+
+       A whole number of units. Braze defaults an absent quantity to 1. A quantity greater than 100 is split across multiple purchase objects (for example, 250 becomes 100, 100, and 50), which preserves the row's total revenue; a single row can carry up to 7,500 units.
+
+.. events-braze-purchases-fields-end
+
+
+.. _events-braze-purchases-workflow-actions:
+
+Workflow actions
+==================================================
+
+.. include:: ../../shared/workflow-actions.rst
+   :start-after: .. workflow-actions-common-table-intro-start
+   :end-before: .. workflow-actions-common-table-intro-end
+
+.. events-braze-purchases-workflow-actions-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-one-a-start
+          :end-before: .. workflow-actions-common-table-section-one-a-end
+
+       .. image:: ../../images/mockup-destinations-tab-workflow-error.png
+          :width: 500 px
+          :alt: Review a notifications error.
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-one-b-start
+          :end-before: .. workflow-actions-common-table-section-one-b-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-two-start
+          :end-before: .. workflow-actions-common-table-section-two-end
+
+       .. image:: ../../images/mockups-workflow-failed.png
+          :width: 500 px
+          :alt: The workflow tab, showing a workflow with errors.
+          :align: left
+          :class: no-scaled-link
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-three-a-start
+          :end-before: .. workflow-actions-common-table-section-three-a-end
+
+       .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-three-b-start
+          :end-before: .. workflow-actions-common-table-section-three-b-end
+
+       Amperity provides a series of workflow actions that can help resolve specific issues that may arise with |destination-name|, including:
+
+       * :ref:`events-braze-purchases-workflow-actions-invalid-credentials`
+       * :ref:`events-braze-purchases-workflow-actions-invalid-settings`
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-four-a-start
+          :end-before: .. workflow-actions-common-table-section-four-a-end
+
+       .. include:: ../../shared/workflow-actions.rst
+          :start-after: .. workflow-actions-common-table-section-four-b-start
+          :end-before: .. workflow-actions-common-table-section-four-b-end
+
+.. events-braze-purchases-workflow-actions-end
+
+.. note:: If Braze rejects an entire request, the workflow reports the error with Braze's message — review the purchase field values returned by your query. If sends are rate limited, Amperity retries automatically; reduce the volume of purchases sent per orchestration if the limit persists.
+
+
+.. _events-braze-purchases-workflow-actions-invalid-credentials:
+
+Invalid credentials
+--------------------------------------------------
+
+.. include:: ../../shared/workflow-actions.rst
+   :start-after: .. workflow-actions-generic-invalid-credentials-start
+   :end-before: .. workflow-actions-generic-invalid-credentials-end
+
+
+.. _events-braze-purchases-workflow-actions-invalid-settings:
+
+Invalid settings
+--------------------------------------------------
+
+.. events-braze-purchases-workflow-actions-invalid-settings-start
+
+The configuration for this workflow has a setting that |destination-name| was unable to accept. Braze returns the same error for a REST API key that is not valid and for a key used against the wrong instance, so verify that the **Instance** matches the instance the REST API key belongs to, and that the key has the **users.track** permission.
+
+.. events-braze-purchases-workflow-actions-invalid-settings-end
+
+.. events-braze-purchases-workflow-actions-invalid-settings-steps-start
+
+To resolve this error, verify the settings configured for this workflow in Amperity.
+
+#. Open the **Destinations** page and review the settings for the |destination-name| destination associated with this workflow. Verify that the **Instance** is correct and that the connected credential's REST API key belongs to that instance and has the **users.track** permission.
+#. Return to the workflow action, and then click **Resolve** to retry this workflow.
+
+.. events-braze-purchases-workflow-actions-invalid-settings-steps-end

--- a/amperity_operator/source/grid_events.rst
+++ b/amperity_operator/source/grid_events.rst
@@ -34,6 +34,10 @@ Set up measurement of events like in-store purchases or venue check-ins.
       :link-type: doc
       :link: events_amazon_capi
 
+   .. grid-item-card:: Braze Purchases
+      :link-type: doc
+      :link: events_braze_purchases
+
    .. grid-item-card:: Criteo
       :link-type: doc
       :link: events_criteo
@@ -79,6 +83,7 @@ Set up measurement of events like in-store purchases or venue check-ins.
    :hidden:
 
    Amazon Ads Conversion API <events_amazon_capi>
+   Braze Purchases <events_braze_purchases>
    Criteo <events_criteo>
    Google Analytics 4 <events_google_analytics>
    Google Enhanced Conversions <events_google_enhanced_conversions>

--- a/amperity_user/source/events_braze_purchases.rst
+++ b/amperity_user/source/events_braze_purchases.rst
@@ -1,0 +1,114 @@
+.. https://docs.amperity.com/user/
+
+
+.. |destination-name| replace:: Braze
+.. |what-send| replace:: purchase events
+.. |where-send| replace:: |destination-name|
+
+.. meta::
+    :description lang=en:
+        Send purchase events from Amperity to Braze.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Send purchase events from Amperity to Braze.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Send purchases to Braze
+
+==================================================
+Send purchases to Braze
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-braze-start
+   :end-before: .. term-braze-end
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-overview-start
+   :end-before: .. events-braze-purchases-overview-end
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-billing-start
+   :end-before: .. events-braze-purchases-billing-end
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-beta-start
+   :end-before: .. events-braze-purchases-beta-end
+
+
+.. _events-braze-purchases-user-build-query:
+
+Build a query
+==================================================
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-build-query-start
+   :end-before: .. events-braze-purchases-build-query-end
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-build-query-required-start
+   :end-before: .. events-braze-purchases-build-query-required-end
+
+
+.. _events-braze-purchases-user-identifiers:
+
+User identifiers
+==================================================
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-user-identifiers-start
+   :end-before: .. events-braze-purchases-user-identifiers-end
+
+
+.. _events-braze-purchases-user-add-orchestration:
+
+Add orchestration
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-orchestration-start
+   :end-before: .. term-orchestration-end
+
+**To add an orchestration**
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-add-orchestration-generic-start
+   :end-before: .. sendtos-add-orchestration-generic-end
+
+
+.. _events-braze-purchases-user-run-orchestration:
+
+Run orchestration
+==================================================
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-start
+   :end-before: .. sendtos-run-orchestration-end
+
+**To run the orchestration**
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-steps-start
+   :end-before: .. sendtos-run-orchestration-steps-end
+
+
+.. _events-braze-purchases-data-validation:
+
+Data validation
+==================================================
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-data-validation-start
+   :end-before: .. events-braze-purchases-data-validation-end
+
+
+.. _events-braze-purchases-fields:
+
+Purchase object fields
+==================================================
+
+.. include:: ../../amperity_operator/source/events_braze_purchases.rst
+   :start-after: .. events-braze-purchases-fields-start
+   :end-before: .. events-braze-purchases-fields-end

--- a/amperity_user/source/grid_events.rst
+++ b/amperity_user/source/grid_events.rst
@@ -39,6 +39,10 @@ Events
       :link-type: ref
       :link: destination-braze-custom-attributes
 
+   .. grid-item-card:: Braze Purchases
+      :link-type: doc
+      :link: events_braze_purchases
+
    .. grid-item-card:: Criteo
       :link-type: doc
       :link: events_criteo
@@ -94,6 +98,7 @@ Events
 
    About events <events>
    Amazon Ads Conversion API <events_amazon_capi>
+   Braze Purchases <events_braze_purchases>
    Criteo <events_criteo>
    Google Ads <events_google_enhanced_conversions>
    Google Analytics 4 <events_google_analytics>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -970,6 +970,18 @@ Required. The API key for your |destination-name| account.
 
 .. credential-braze-api-key-end
 
+.. credential-braze-purchases-api-key-start
+
+Required. The Braze REST API key for your |destination-name| account. The key must have the **users.track** permission.
+
+.. credential-braze-purchases-api-key-end
+
+.. credential-braze-purchases-api-find-key-start
+
+Create or find a REST API key in the Braze dashboard under **Settings > API Keys**. The key must include the **users.track** permission. A REST API key is scoped to a single Braze instance, so the key must belong to the same instance you configure for this destination.
+
+.. credential-braze-purchases-api-find-key-end
+
 
 
 

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -1215,6 +1215,14 @@ A query must return one row per purchase, including a column for the selected **
 
 .. setting-braze-purchases-query-must-return-end
 
+.. setting-braze-purchases-update-existing-only-start
+
+Use the **Update existing profiles only?** option to `update only existing user profiles in Braze <https://www.braze.com/docs/api/objects_filters/purchase_object/>`__ |ext_link|. When this setting is not enabled, Braze creates a new user profile for a purchase that does not match an existing profile.
+
+When this setting is enabled, Braze accepts a purchase for a user it cannot match but does not record it: the row is reported as succeeded, no revenue is added, and nothing appears on a profile. Enable this option only when every user you send is already known to Braze.
+
+.. setting-braze-purchases-update-existing-only-end
+
 
 
 

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -1203,6 +1203,18 @@ Use the **Update existing profiles only?** option to `update only existing user 
 
 .. setting-braze-update-existing-profiles-end
 
+.. setting-braze-purchases-instance-start
+
+Required. Select the `Braze instance <https://www.braze.com/docs/user_guide/administrative/access_braze/braze_instances>`__ |ext_link| where your account is provisioned. May be one of "US-01", "US-02", "US-03", "US-04", "US-05", "US-06", "US-07", "US-08", "US-10", "EU-01", "EU-02", "AU-01", "ID-01", "JP-01", or "KR-01". This must be the same instance the REST API key belongs to.
+
+.. setting-braze-purchases-instance-end
+
+.. setting-braze-purchases-query-must-return-start
+
+A query must return one row per purchase, including a column for the selected **User identifier** and columns for **product_id**, **price**, **currency**, and **purchase_time**. A **quantity** column is optional.
+
+.. setting-braze-purchases-query-must-return-end
+
 
 
 


### PR DESCRIPTION
## Summary

Documents the Braze Purchases connector (INT-22) as beta. Braze Purchases sends one
Braze purchase object per query row to the Braze REST API /users/track endpoint,
matched to a Braze user profile by the chosen identifier (braze_id, external_id, or
user_alias). It is an event-forwarding connector (offline-events archetype), separate
from the Braze attribute-sync and Braze Cohorts connectors.

All content is grounded in /app/ (the braze-purchases plugin: specification, transforms,
api, destination, error). Modeled on the Roku CAPI event connector, minus the identity-
hashing sections, which do not apply here.

Terminology is indexed to Braze's own wording ("purchases"); the internal "CAPI" name
does not appear in the docs. The connector/UI name is "Braze Purchases".

## What's included

- Operator page: events_braze_purchases.rst (overview, billing caution, get details,
  configure credentials, add destination, build a query, user identifiers, data
  validation, purchase object fields, workflow actions)
- User page: events_braze_purchases.rst
- Modal: destination-braze-purchases.rst
- Shared snippets: credential-braze-purchases-api-key (+ find-key, naming the users.track
  permission); setting-braze-purchases-instance (15 instances) and -query-must-return.
  Reuses setting-braze-user-identifier and setting-braze-update-existing-profiles.
- Registration: operator + user grid_events, and the modal index

## Verification

make operator, user, and modals all build clean with -W.

## Reviewer notes

- Beta: the connector is verified against Braze's live workspace but the spec still
  carries work-in-progress? true; the docs lead the flag removal, matching prior event-
  connector releases (Roku CAPI, Amazon CAPI).
- price is documented as a per-unit value (Braze computes revenue as price x quantity);
  the example query divides a line total by quantity.