### PR TITLE
Dynamic yield connector 49875

### DIFF
--- a/amperity_base/source/_templates/destinations.html
+++ b/amperity_base/source/_templates/destinations.html
@@ -665,6 +665,22 @@
     </a>
 
 
+    <a href="/operator/destination_dynamic_yield_customer_profiles.html" class="card">
+      <div class="card-content" title="Dynamic Yield Customer Profiles">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-dynamic-yield.svg" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-dynamic-yield-dark.svg" class="card-image" />
+        </figure>
+        <div class="card-title">Dynamic Yield Customer Profiles</div>
+        <div class="card-description">
+          Send customer profile attributes to a Dynamic Yield User Data feed.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/destination_dynamics_365_marketing.html" class="card">
       <div class="card-content" title="Dynamics 365 Marketing">
         <figure class="light-only align-center">

--- a/amperity_modals/source/destination-dynamic-yield-customer-profiles.rst
+++ b/amperity_modals/source/destination-dynamic-yield-customer-profiles.rst
@@ -1,0 +1,82 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: Dynamic Yield
+.. |what-send| replace:: customer profile attributes
+.. |where-send| replace:: a |destination-name| User Data feed
+
+
+Dynamic Yield Customer Profiles
+==================================================
+
+Send |what-send| from Amperity into |where-send| to keep |destination-name|'s on-site personalization and recommendation engine current with unified customer profile data.
+
+.. admonition:: Beta
+
+   The Dynamic Yield Customer Profiles connector is currently in beta. Contact your Amperity representative to learn more.
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**API Key**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-dynamic-yield-customer-profiles-api-key-start
+   :end-before: .. credential-dynamic-yield-customer-profiles-api-key-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Feed key**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-dynamic-yield-customer-profiles-feed-key-start
+   :end-before: .. setting-dynamic-yield-customer-profiles-feed-key-end
+
+**Data center**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-dynamic-yield-customer-profiles-data-center-start
+   :end-before: .. setting-dynamic-yield-customer-profiles-data-center-end
+
+**CUID field**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-dynamic-yield-customer-profiles-cuid-field-start
+   :end-before: .. setting-dynamic-yield-customer-profiles-cuid-field-end
+
+**CUID type**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-dynamic-yield-customer-profiles-cuid-type-start
+   :end-before: .. setting-dynamic-yield-customer-profiles-cuid-type-end
+
+**Operation**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-dynamic-yield-customer-profiles-operation-start
+   :end-before: .. setting-dynamic-yield-customer-profiles-operation-end

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -41,6 +41,7 @@ Site Index
    destination-criteo-retail-media
    destination-cross-country-computer
    destination-dotdigital
+   destination-dynamic-yield-customer-profiles
    destination-dynamics-365-marketing
    destination-dynamics
    destination-eloqua

--- a/amperity_operator/source/destination_dynamic_yield_customer_profiles.rst
+++ b/amperity_operator/source/destination_dynamic_yield_customer_profiles.rst
@@ -1,0 +1,316 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Dynamic Yield
+.. |plugin-name| replace:: "Dynamic Yield Customer Profiles"
+.. |credential-type| replace:: "dynamic-yield-customer-profiles"
+.. |required-credentials| replace:: "API Key"
+.. |what-send| replace:: customer profile attributes
+.. |where-send| replace:: a |destination-name| User Data feed
+.. |filter-the-list| replace:: "dyn"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send customer profile attributes to a Dynamic Yield User Data feed.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send customer profile attributes to a Dynamic Yield User Data feed.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure destinations for Dynamic Yield Customer Profiles
+
+==========================================================
+Configure destinations for Dynamic Yield Customer Profiles
+==========================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-dynamic-yield-start
+   :end-before: .. term-dynamic-yield-end
+
+.. destination-dynamic-yield-customer-profiles-start
+
+The Dynamic Yield Customer Profiles connector sends |what-send| from Amperity into |where-send|, which keeps |destination-name|'s on-site personalization and recommendation engine current with unified customer profile data.
+
+Each row in the query results is one customer profile. The column named by the **CUID field** setting is sent as the customer identifier; every other column is sent as a profile data field, using the column name and value as-is. |destination-name| requires every attribute to be sent on every update for a customer, so Amperity sends the complete query results on every run. There is no incremental sync.
+
+.. .. destination-dynamic-yield-customer-profiles-end
+
+.. destination-dynamic-yield-customer-profiles-api-note-start
+
+.. note:: This destination uses the `Dynamic Yield User Data API <https://dy.dev/reference/user-data-api>`__ |ext_link|.
+
+.. destination-dynamic-yield-customer-profiles-api-note-end
+
+.. destination-dynamic-yield-customer-profiles-beta-start
+
+.. admonition:: Beta
+
+   The Dynamic Yield Customer Profiles connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-dynamic-yield-customer-profiles-beta-end
+
+.. destination-dynamic-yield-customer-profiles-prereq-start
+
+.. note:: The feed and its schema must already exist in |destination-name|. An account admin creates and activates the feed's schema in the |destination-name| console (**Assets > Data Feeds**) before Amperity can send data to it. Amperity sends data to a feed, but cannot create a feed or its schema.
+
+.. destination-dynamic-yield-customer-profiles-prereq-end
+
+
+.. _destination-dynamic-yield-customer-profiles-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-dynamic-yield-customer-profiles-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **API Key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-dynamic-yield-customer-profiles-api-key-start
+             :end-before: .. credential-dynamic-yield-customer-profiles-api-key-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Feed key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-feed-key-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-feed-key-end
+
+       **CUID field**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-cuid-field-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-cuid-field-end
+
+       **CUID type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-cuid-type-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-cuid-type-end
+
+
+.. destination-dynamic-yield-customer-profiles-get-details-end
+
+
+.. _destination-dynamic-yield-customer-profiles-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Dynamic Yield Customer Profiles**
+
+.. destination-dynamic-yield-customer-profiles-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **API Key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-dynamic-yield-customer-profiles-api-key-start
+             :end-before: .. credential-dynamic-yield-customer-profiles-api-key-end
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-dynamic-yield-customer-profiles-api-find-key-start
+             :end-before: .. credential-dynamic-yield-customer-profiles-api-find-key-end
+
+.. destination-dynamic-yield-customer-profiles-credentials-steps-end
+
+
+.. _destination-dynamic-yield-customer-profiles-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Dynamic Yield Customer Profiles**
+
+.. destination-dynamic-yield-customer-profiles-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Feed key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-feed-key-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-feed-key-end
+
+       **Data center**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-data-center-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-data-center-end
+
+       **CUID field**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-cuid-field-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-cuid-field-end
+
+       **CUID type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-cuid-type-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-cuid-type-end
+
+       **Operation**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-operation-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-operation-end
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-orchestration-only-start
+          :end-before: .. destinations-steps-business-users-orchestration-only-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. destination-dynamic-yield-customer-profiles-add-steps-end

--- a/amperity_operator/source/destination_dynamic_yield_customer_profiles.rst
+++ b/amperity_operator/source/destination_dynamic_yield_customer_profiles.rst
@@ -36,6 +36,8 @@ The Dynamic Yield Customer Profiles connector sends |what-send| from Amperity in
 
 Each row in the query results is one customer profile. The column named by the **CUID field** setting is sent as the customer identifier; every other column is sent as a profile data field, using the column name and value as-is. |destination-name| requires every attribute to be sent on every update for a customer, so Amperity sends the complete query results on every run. There is no incremental sync.
 
+By default the connector upserts profiles, adding new customers and updating existing ones. A destination can instead be configured to delete profiles, removing each customer in the query results from the feed. Each destination performs a single operation for the entire run, set by the **Operation** setting.
+
 .. .. destination-dynamic-yield-customer-profiles-end
 
 .. destination-dynamic-yield-customer-profiles-api-note-start
@@ -114,6 +116,26 @@ Get details
           .. include:: ../../shared/destination_settings.rst
              :start-after: .. setting-dynamic-yield-customer-profiles-cuid-type-start
              :end-before: .. setting-dynamic-yield-customer-profiles-cuid-type-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - **Optional configuration settings**
+
+       **Data center**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-data-center-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-data-center-end
+
+       **Operation**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-dynamic-yield-customer-profiles-operation-start
+             :end-before: .. setting-dynamic-yield-customer-profiles-operation-end
 
 
 .. destination-dynamic-yield-customer-profiles-get-details-end
@@ -314,3 +336,21 @@ Add destination
           :end-before: .. destinations-steps-validate-audience-end
 
 .. destination-dynamic-yield-customer-profiles-add-steps-end
+
+
+.. _destination-dynamic-yield-customer-profiles-validation:
+
+Data validation
+==================================================
+
+.. destination-dynamic-yield-customer-profiles-validation-start
+
+Amperity sends every row in the query results, except for rows it cannot build a valid request for. A row is skipped and reported as failed when any of the following is true:
+
+* The **CUID field** is empty for that row.
+* The **CUID type** is **he** (hashed email) but the value in the CUID field is not an email address (does not contain an "@"). The value is not hashed and the row is not sent.
+* The **Operation** is **upsert** and the row has no columns other than the CUID field, so there are no profile attributes to send.
+
+Skipped rows are reported in the destination's run details and do not stop the run. All other rows are sent.
+
+.. destination-dynamic-yield-customer-profiles-validation-end

--- a/amperity_operator/source/grid_destinations.rst
+++ b/amperity_operator/source/grid_destinations.rst
@@ -166,6 +166,10 @@ Set up connections to send data from Amperity to other marketing applications, t
       :link-type: doc
       :link: destination_dynamic_yield
 
+   .. grid-item-card:: Dynamic Yield Customer Profiles
+      :link-type: doc
+      :link: destination_dynamic_yield_customer_profiles
+
    .. grid-item-card:: Dynamics 365 Marketing
       :link-type: doc
       :link: destination_dynamics_365_marketing
@@ -467,6 +471,7 @@ Set up connections to send data from Amperity to other marketing applications, t
    Dotdigital <destination_dotdigital>
    DV360 <destination_dv360>
    Dynamic Yield <destination_dynamic_yield>
+   Dynamic Yield Customer Profiles <destination_dynamic_yield_customer_profiles>
    Dynamics 365 Marketing <destination_dynamics_365_marketing>
    Epsilon Abacus <destination_epsilon_abacus>
    Epsilon Conversant <destination_epsilon_conversant>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -2167,6 +2167,18 @@ The Salesforce security token associated with the username. This setting is not 
 
 .. credential-salesforce-sales-cloud-security-token-end
 
+.. credential-dynamic-yield-customer-profiles-api-key-start
+
+The |destination-name| API key that authenticates each request. Each API key is scoped to a single feed and must be generated with the **User Feed** ACL.
+
+.. credential-dynamic-yield-customer-profiles-api-key-end
+
+.. credential-dynamic-yield-customer-profiles-api-find-key-start
+
+Generate the API key in |destination-name| by navigating to **Settings > API Keys** and creating a key with the ACL set to **User Feed**. A key created with any other ACL type, or a client-side key, is rejected.
+
+.. credential-dynamic-yield-customer-profiles-api-find-key-end
+
 **Username and password**
 
 .. credential-salesforce-sales-cloud-username-and-password-start

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -2862,6 +2862,35 @@ When enabled, empty fields in data sent from Amperity are converted to **NULL** 
 
 .. setting-salesforce-sales-cloud-use-null-for-empty-fields-end
 
+.. setting-dynamic-yield-customer-profiles-feed-key-start
+
+The feed's key, copied from the feed's settings in |destination-name|. Each User Data feed has its own key and is tied to a single customer's feed. The feed and its schema must already exist in |destination-name|; Amperity sends data to a feed but cannot create one.
+
+.. setting-dynamic-yield-customer-profiles-feed-key-end
+
+.. setting-dynamic-yield-customer-profiles-data-center-start
+
+The |destination-name| data center in which the account is provisioned, which determines the API base URL. Select **us** or **eu**. Defaults to **us**.
+
+.. setting-dynamic-yield-customer-profiles-data-center-end
+
+.. setting-dynamic-yield-customer-profiles-cuid-field-start
+
+The name of the column in the query results that holds the customer identifier (``cuid``) to send with every request. Every other column in the query results is sent to the feed as a data field, using the column name and value as-is.
+
+.. setting-dynamic-yield-customer-profiles-cuid-field-end
+
+.. setting-dynamic-yield-customer-profiles-cuid-type-start
+
+The identifier type that |destination-name| expects for ``cuid``, which must match how the feed itself is configured. Use **he** for a hashed email (Amperity hashes the value in the CUID field automatically, so the query results can carry a raw email address), **dyid** for Dynamic Yield's own user ID, or a custom type configured for the feed. When **he** is selected, a value that is not an email address (does not contain an "@") is skipped and reported, rather than hashed.
+
+.. setting-dynamic-yield-customer-profiles-cuid-type-end
+
+.. setting-dynamic-yield-customer-profiles-operation-start
+
+The operation applied to every row in the query results: **upsert** (the default) adds or updates each customer's profile in the feed, and **delete** removes each customer's profile from the feed. A destination performs a single operation for the entire run, not a mix. An upsert sends every column besides the CUID field as profile data; a delete sends only the identifier.
+
+.. setting-dynamic-yield-customer-profiles-operation-end
 
 
 


### PR DESCRIPTION
Summary

Documents the Dynamic Yield Customer Profiles destination connector (INT-23) as beta. This is a profile/attribute full-upsert destination (archetype 5, same shape as Salesforce Sales Cloud): it sends query-result rows into a Dynamic Yield User Data feed via the User Data API, with no PluginSchema and no audience/deltalog concept. The column named by the CUID field is the customer identifier; every other column is sent as profile data verbatim. Dynamic Yield requires all attributes on every update, so the connector re-sends the full query results each run (no incremental sync). The connector can also delete profiles (Operation setting).

All content is grounded in /app/ (the dynamic-yield-customer-profiles plugin: specification, transforms, api, destination, error). This is distinct from the existing S3-based Dynamic Yield product-catalog destination (destination_dynamic_yield) — a separate, older integration.

 What's included

 - Operator destination topic: destination_dynamic_yield_customer_profiles.rst (overview, feed/schema prerequisite, API note, Beta admonition, get details, configure credentials, add destination, data validation)
 - Modal: destination-dynamic-yield-customer-profiles.rst
 - Shared snippets: credential-dynamic-yield-customer-profiles-api-key (+ find-key, naming the User Feed ACL); setting-dynamic-yield-customer-profiles-{feed-key, data-center, cuid-field, cuid-type, operation}. Reuses the existing term-dynamic-yield.
 - Registration: operator grid_destinations (card + toctree), modal index, base destinations.html card

 Operator-only footprint (no user or campaign topic), matching the Salesforce Sales Cloud archetype-5 precedent — the connector has no audience-membership or campaign-activation path.

 Verification

 make operator, modals, and base all build clean with -W.

 Reviewer notes

 - Beta: the connector is beta? true but still work-in-progress? true (hidden from the picker); the docs lead the flag removal, matching prior beta connector releases.
 - Docs lead live verification: the connector has not yet been verified against a live Dynamic Yield account (no test account/credentials provisioned). Every status-code mapping, rate limit, and batch size in /app/ is transcribed from vendor documentation. The docs claim only what the code does; none of those unverified internals appear in user-facing text.
- The public destinations.html landing card and grid_destinations registration are intentional (docs-first) while the connector is still work-in-progress. Remove the card if it should stay invisible until the WIP flag flips — the operator topic and modal are independent of it.
 - Logo reuses the existing connector-dynamic-yield.svg (same vendor); a dedicated marketing logo is still pending but does not block the build.