### PR TITLE
Opera outbound 59875

### DIFF
--- a/amperity_base/source/_templates/destinations.html
+++ b/amperity_base/source/_templates/destinations.html
@@ -1321,6 +1321,22 @@
     </a>
 
 
+    <a href="/operator/destination_oracle_opera_outbound.html" class="card">
+      <div class="card-content" title="Oracle Opera (Outbound)">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-oracle.svg" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-oracle.svg" class="card-image" />
+        </figure>
+        <div class="card-title">Oracle Opera (Outbound)</div>
+        <div class="card-description">
+          Send guest profiles to a property's Oracle OPERA Cloud profile database.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/destination_oracle_responsys.html" class="card">
       <div class="card-content" title="Oracle Responsys">
         <figure class="light-only align-center">

--- a/amperity_modals/source/destination-oracle-opera-outbound.rst
+++ b/amperity_modals/source/destination-oracle-opera-outbound.rst
@@ -1,0 +1,100 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: Oracle OPERA
+.. |what-send| replace:: guest profiles
+.. |where-send| replace:: a property's |destination-name| profile database
+
+
+Oracle Opera (Outbound)
+==================================================
+
+Send |what-send| from Amperity into |where-send|, so property staff see unified names and contact details for each guest. Each guest is looked up by their Amperity ID, then updated in place or created when the property does not hold them yet.
+
+.. admonition:: Beta
+
+   The Oracle Opera (Outbound) connector is currently in beta. Contact your Amperity representative to learn more.
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**Client ID**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-client-id-start
+   :end-before: .. credential-oracle-opera-outbound-client-id-end
+
+**Client Secret**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-client-secret-start
+   :end-before: .. credential-oracle-opera-outbound-client-secret-end
+
+**Application Key**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-app-key-start
+   :end-before: .. credential-oracle-opera-outbound-app-key-end
+
+**Gateway URL**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-gateway-url-start
+   :end-before: .. credential-oracle-opera-outbound-gateway-url-end
+
+**Enterprise ID**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-enterprise-id-start
+   :end-before: .. credential-oracle-opera-outbound-enterprise-id-end
+
+**Hotel ID**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-hotel-id-start
+   :end-before: .. credential-oracle-opera-outbound-hotel-id-end
+
+**External System Code**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-oracle-opera-outbound-external-system-code-start
+   :end-before: .. credential-oracle-opera-outbound-external-system-code-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Profile type**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-oracle-opera-outbound-profile-type-start
+   :end-before: .. setting-oracle-opera-outbound-profile-type-end
+
+**Primary key**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-oracle-opera-outbound-primary-key-start
+   :end-before: .. setting-oracle-opera-outbound-primary-key-end

--- a/amperity_modals/source/destination-oracle-opera-outbound.rst
+++ b/amperity_modals/source/destination-oracle-opera-outbound.rst
@@ -37,12 +37,6 @@ Credentials
    :start-after: .. credential-oracle-opera-outbound-client-secret-start
    :end-before: .. credential-oracle-opera-outbound-client-secret-end
 
-**Application Key**
-
-.. include:: ../../shared/credentials_settings.rst
-   :start-after: .. credential-oracle-opera-outbound-app-key-start
-   :end-before: .. credential-oracle-opera-outbound-app-key-end
-
 **Gateway URL**
 
 .. include:: ../../shared/credentials_settings.rst

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -76,6 +76,7 @@ Site Index
    destination-moengage
    destination-neustar
    destination-oracle-data-cloud
+   destination-oracle-opera-outbound
    destination-oracle-responsys
    destination-panda-printing
    destination-pebble-post

--- a/amperity_operator/source/destination_oracle_opera_outbound.rst
+++ b/amperity_operator/source/destination_oracle_opera_outbound.rst
@@ -1,0 +1,370 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Oracle OPERA
+.. |plugin-name| replace:: "Oracle Opera (Outbound)"
+.. |credential-type| replace:: "oracle-opera-outbound"
+.. |required-credentials| replace:: "Client ID", "Client Secret", "Application Key", "Gateway URL", "Enterprise ID", "Hotel ID", and "External System Code"
+.. |what-send| replace:: guest profiles
+.. |where-send| replace:: a property's |destination-name| profile database
+.. |filter-the-list| replace:: "opera"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send guest profiles to Oracle OPERA Cloud.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send guest profiles to Oracle OPERA Cloud.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure destinations for Oracle Opera (Outbound)
+
+===================================================
+Configure destinations for Oracle Opera (Outbound)
+===================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-oracle-opera-start
+   :end-before: .. term-oracle-opera-end
+
+.. destination-oracle-opera-outbound-start
+
+The Oracle Opera (Outbound) connector sends |what-send| from Amperity into |where-send|, so property staff see unified names and contact details for each guest.
+
+Each guest is identified by their Amperity ID alone, which Amperity writes into |destination-name| as an external reference under the property's external system code. Guests are not matched on name, email, or phone. Because |destination-name| has no upsert operation, each guest is first looked up by their Amperity ID: a guest the property already holds is updated in place, and a guest it does not hold yet is created and stamped with the Amperity ID so that later runs find them again.
+
+Amperity sends only the guests whose mapped fields changed since the last run.
+
+The **Amperity ID** and **surname** fields are required; **given name**, **birth date**, **email**, and **phone** are optional. No other data is sent.
+
+.. .. destination-oracle-opera-outbound-end
+
+.. destination-oracle-opera-outbound-api-note-start
+
+.. note:: This destination uses the `Oracle Hospitality Integration Platform (OHIP) CRM API <https://docs.oracle.com/en/industries/hospitality/integration-platform/ohipu/c_oracle_hospitality_apis.htm>`__ |ext_link|.
+
+.. destination-oracle-opera-outbound-api-note-end
+
+.. destination-oracle-opera-outbound-beta-start
+
+.. admonition:: Beta
+
+   The Oracle Opera (Outbound) connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-oracle-opera-outbound-beta-end
+
+.. destination-oracle-opera-outbound-prereq-start
+
+.. important:: Before Amperity can write any guest, the property must register Amperity as an external system and provide its code as the **External System Code** credential. In |destination-name| Cloud, create the entry under **Administration > Interfaces > Business Events > External Systems**, link it to the property under **Toolbox > System Setup > External Databases**, and confirm that it is active. Amperity verifies this once per run and stops before the first write when the code is missing or inactive. The external system code is the connector's only notion of guest identity.
+
+.. note:: |destination-name| adds a changed email or phone number alongside the value it already holds rather than replacing it, so a previous value can remain on the profile. Clearing a field in Amperity does not remove it from |destination-name|. This ensures Amperity never overwrites contact details that property staff entered directly in |destination-name|.
+
+.. destination-oracle-opera-outbound-prereq-end
+
+
+.. _destination-oracle-opera-outbound-get-details:
+
+Get details
+===================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-oracle-opera-outbound-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       |checkmark-required| **Required**
+
+       All seven credential fields are required. No call can be made without the whole set.
+
+       **Client ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-client-id-start
+             :end-before: .. credential-oracle-opera-outbound-client-id-end
+
+       **Client Secret**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-client-secret-start
+             :end-before: .. credential-oracle-opera-outbound-client-secret-end
+
+       **Application Key**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-app-key-start
+             :end-before: .. credential-oracle-opera-outbound-app-key-end
+
+       **Gateway URL**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-gateway-url-start
+             :end-before: .. credential-oracle-opera-outbound-gateway-url-end
+
+       **Enterprise ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-enterprise-id-start
+             :end-before: .. credential-oracle-opera-outbound-enterprise-id-end
+
+       **Hotel ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-hotel-id-start
+             :end-before: .. credential-oracle-opera-outbound-hotel-id-end
+
+       **External System Code**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-external-system-code-start
+             :end-before: .. credential-oracle-opera-outbound-external-system-code-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Profile type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-oracle-opera-outbound-profile-type-start
+             :end-before: .. setting-oracle-opera-outbound-profile-type-end
+
+       **Primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-oracle-opera-outbound-primary-key-start
+             :end-before: .. setting-oracle-opera-outbound-primary-key-end
+
+
+.. destination-oracle-opera-outbound-get-details-end
+
+
+.. _destination-oracle-opera-outbound-credentials:
+
+Configure credentials
+===================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Oracle Opera (Outbound)**
+
+.. destination-oracle-opera-outbound-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       |checkmark-required| **Required**
+
+       All seven credential fields are required.
+
+       **Client ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-client-id-start
+             :end-before: .. credential-oracle-opera-outbound-client-id-end
+
+       **Client Secret**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-client-secret-start
+             :end-before: .. credential-oracle-opera-outbound-client-secret-end
+
+       **Application Key**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-app-key-start
+             :end-before: .. credential-oracle-opera-outbound-app-key-end
+
+       **Gateway URL**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-gateway-url-start
+             :end-before: .. credential-oracle-opera-outbound-gateway-url-end
+
+       **Enterprise ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-enterprise-id-start
+             :end-before: .. credential-oracle-opera-outbound-enterprise-id-end
+
+       **Hotel ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-hotel-id-start
+             :end-before: .. credential-oracle-opera-outbound-hotel-id-end
+
+       **External System Code**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-oracle-opera-outbound-external-system-code-start
+             :end-before: .. credential-oracle-opera-outbound-external-system-code-end
+
+.. destination-oracle-opera-outbound-credentials-steps-end
+
+
+.. _destination-oracle-opera-outbound-add:
+
+Add destination
+===================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Oracle Opera (Outbound)**
+
+.. destination-oracle-opera-outbound-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Profile type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-oracle-opera-outbound-profile-type-start
+             :end-before: .. setting-oracle-opera-outbound-profile-type-end
+
+       **Primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-oracle-opera-outbound-primary-key-start
+             :end-before: .. setting-oracle-opera-outbound-primary-key-end
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-orchestration-only-start
+          :end-before: .. destinations-steps-business-users-orchestration-only-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. destination-oracle-opera-outbound-add-steps-end

--- a/amperity_operator/source/destination_oracle_opera_outbound.rst
+++ b/amperity_operator/source/destination_oracle_opera_outbound.rst
@@ -4,7 +4,7 @@
 .. |destination-name| replace:: Oracle OPERA
 .. |plugin-name| replace:: "Oracle Opera (Outbound)"
 .. |credential-type| replace:: "oracle-opera-outbound"
-.. |required-credentials| replace:: "Client ID", "Client Secret", "Application Key", "Gateway URL", "Enterprise ID", "Hotel ID", and "External System Code"
+.. |required-credentials| replace:: "Client ID", "Client Secret", "Gateway URL", "Enterprise ID", "Hotel ID", and "External System Code"
 .. |what-send| replace:: guest profiles
 .. |where-send| replace:: a property's |destination-name| profile database
 .. |filter-the-list| replace:: "opera"
@@ -40,7 +40,7 @@ Amperity sends only the guests whose mapped fields changed since the last run.
 
 The **Amperity ID** and **surname** fields are required; **given name**, **birth date**, **email**, and **phone** are optional. No other data is sent.
 
-.. .. destination-oracle-opera-outbound-end
+.. destination-oracle-opera-outbound-end
 
 .. destination-oracle-opera-outbound-api-note-start
 
@@ -89,7 +89,7 @@ Get details
 
        |checkmark-required| **Required**
 
-       All seven credential fields are required. No call can be made without the whole set.
+       All six credential fields are required. No call can be made without the whole set.
 
        **Client ID**
 
@@ -102,12 +102,6 @@ Get details
           .. include:: ../../shared/credentials_settings.rst
              :start-after: .. credential-oracle-opera-outbound-client-secret-start
              :end-before: .. credential-oracle-opera-outbound-client-secret-end
-
-       **Application Key**
-
-          .. include:: ../../shared/credentials_settings.rst
-             :start-after: .. credential-oracle-opera-outbound-app-key-start
-             :end-before: .. credential-oracle-opera-outbound-app-key-end
 
        **Gateway URL**
 
@@ -207,7 +201,7 @@ Configure credentials
 
        |checkmark-required| **Required**
 
-       All seven credential fields are required.
+       All six credential fields are required.
 
        **Client ID**
 
@@ -220,12 +214,6 @@ Configure credentials
           .. include:: ../../shared/credentials_settings.rst
              :start-after: .. credential-oracle-opera-outbound-client-secret-start
              :end-before: .. credential-oracle-opera-outbound-client-secret-end
-
-       **Application Key**
-
-          .. include:: ../../shared/credentials_settings.rst
-             :start-after: .. credential-oracle-opera-outbound-app-key-start
-             :end-before: .. credential-oracle-opera-outbound-app-key-end
 
        **Gateway URL**
 

--- a/amperity_operator/source/grid_destinations.rst
+++ b/amperity_operator/source/grid_destinations.rst
@@ -302,6 +302,10 @@ Set up connections to send data from Amperity to other marketing applications, t
       :link-type: doc
       :link: destination_oracle_eloqua
 
+   .. grid-item-card:: Oracle Opera (Outbound)
+      :link-type: doc
+      :link: destination_oracle_opera_outbound
+
    .. grid-item-card:: Oracle Responsys
       :link-type: doc
       :link: destination_oracle_responsys
@@ -501,6 +505,7 @@ Set up connections to send data from Amperity to other marketing applications, t
    Optimizely <destination_optimizely>
    Oracle Data Cloud <destination_oracle_data_cloud>
    Oracle Eloqua <destination_oracle_eloqua>
+   Oracle Opera (Outbound) <destination_oracle_opera_outbound>
    Oracle Responsys <destination_oracle_responsys>
    Panda Printing <destination_panda_printing>
    PebblePost <destination_pebblepost>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -1820,6 +1820,70 @@ See SFTP.
 
 .. vale off
 
+**ORACLE OPERA (OUTBOUND)**
+
+.. vale on
+
+**Client ID**
+
+.. credential-oracle-opera-outbound-client-id-start
+
+OAuth client ID from the OHIP Developer Portal (**Environment > Gateways and Credentials**).
+
+.. credential-oracle-opera-outbound-client-id-end
+
+**Client Secret**
+
+.. credential-oracle-opera-outbound-client-secret-start
+
+OAuth client secret from the OHIP Developer Portal.
+
+.. credential-oracle-opera-outbound-client-secret-end
+
+**Application Key**
+
+.. credential-oracle-opera-outbound-app-key-start
+
+Application key for your OHIP application, from the OHIP Developer Portal (**Applications**). It is sent on every call and identifies the application to Oracle, so OHIP API usage is billed to your own OHIP subscription. Oracle requires a separate application per environment: a key registered against a different environment is rejected with a ``403``.
+
+.. credential-oracle-opera-outbound-app-key-end
+
+**Gateway URL**
+
+.. credential-oracle-opera-outbound-gateway-url-start
+
+The OHIP gateway base URL, for example ``https://<tenant>.hospitality-api.<region>.ocs.oraclecloud.com``.
+
+.. credential-oracle-opera-outbound-gateway-url-end
+
+**Enterprise ID**
+
+.. credential-oracle-opera-outbound-enterprise-id-start
+
+The enterprise ID for the OPERA Cloud environment. Required on the token request for OCIM environments.
+
+.. credential-oracle-opera-outbound-enterprise-id-end
+
+**Hotel ID**
+
+.. credential-oracle-opera-outbound-hotel-id-start
+
+The default ``x-hotelid`` for CRM calls, which is the property that profiles are written to.
+
+.. credential-oracle-opera-outbound-hotel-id-end
+
+**External System Code**
+
+.. credential-oracle-opera-outbound-external-system-code-start
+
+The code the property has configured for Amperity as an external system (in OPERA Cloud: **Administration > Interfaces > Business Events > External Systems**, linked to the property under **Toolbox > System Setup > External Databases**). The Amperity ID is stored on each OPERA profile under this code, which is how every run finds the guest again.
+
+.. credential-oracle-opera-outbound-external-system-code-end
+
+
+
+.. vale off
+
 **ORACLE RESPONSYS**
 
 **Hostname**

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -1840,14 +1840,6 @@ OAuth client secret from the OHIP Developer Portal.
 
 .. credential-oracle-opera-outbound-client-secret-end
 
-**Application Key**
-
-.. credential-oracle-opera-outbound-app-key-start
-
-Application key for your OHIP application, from the OHIP Developer Portal (**Applications**). It is sent on every call and identifies the application to Oracle, so OHIP API usage is billed to your own OHIP subscription. Oracle requires a separate application per environment: a key registered against a different environment is rejected with a ``403``.
-
-.. credential-oracle-opera-outbound-app-key-end
-
 **Gateway URL**
 
 .. credential-oracle-opera-outbound-gateway-url-start

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -2444,6 +2444,33 @@ This approach requires adding an empty shared list to |destination-name|, and th
 
 .. vale off
 
+**ORACLE OPERA (OUTBOUND)**
+
+.. vale on
+
+Settings unique to Oracle Opera (Outbound).
+
+**Profile type**
+
+.. setting-oracle-opera-outbound-profile-type-start
+
+The OPERA profile type to create or update. Most hospitality use cases use **Guest**. Options are **Guest**, **Contact**, **Company**, and **Agent**. The default is **Guest**.
+
+.. setting-oracle-opera-outbound-profile-type-end
+
+**Primary key**
+
+.. setting-oracle-opera-outbound-primary-key-start
+
+The field that identifies a guest across runs. The Amperity ID is stable, unlike a guest's OPERA attributes. Set to **external_id**.
+
+.. setting-oracle-opera-outbound-primary-key-end
+
+
+
+
+.. vale off
+
 **PANDA PRINTING**
 
 .. vale on


### PR DESCRIPTION
 Summary
▎ Adds Beta documentation for the Oracle Opera (Outbound) destination connector (oracle-opera-outbound), which writes Amperity guest profiles into a property's Oracle OPERA Cloud profile database via the OHIP CRM API. Authored from app PR #71374, which promotes the connector from a WIP pilot to Beta. Archetype-5 profile lookup-then-write (attribute deltalog, operator-only) — no user or campaign topic, matching Salesforce Sales Cloud / Dynamic Yield Customer Profiles.
▎
▎ Included
▎ - Operator topic destination_oracle_opera_outbound.rst (canonical) + modal destination-oracle-opera-outbound.rst.
▎ - Shared snippets: 7 credential fields + 2 settings (profile type, primary key).
▎ - Registration: grid_destinations (card + toctree), modal index, base destinations landing card. Reuses term-oracle-opera and connector-oracle.svg.
▎
▎ Verification: operator, modals, and base build -W clean.
▎
▎ Reviewer notes: Beta label reflects ::plugin/beta? in PR #71374 (not yet merged to main; main still carries the WIP pilot). Behavior is cited to the PR. The inbound oracle-opera source topic is unchanged.