### PR TITLE
Remove Beta admonitions from Viant DSP docs

### DIFF
--- a/amperity_modals/source/destination-viant-dsp.rst
+++ b/amperity_modals/source/destination-viant-dsp.rst
@@ -14,14 +14,6 @@ Viant DSP
    :start-after: .. term-viant-dsp-start
    :end-before: .. term-viant-dsp-end
 
-.. destination-viant-dsp-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. destination-viant-dsp-beta-end
-
 
 Credentials
 ==================================================

--- a/amperity_operator/source/campaign_viant_dsp.rst
+++ b/amperity_operator/source/campaign_viant_dsp.rst
@@ -44,14 +44,6 @@ Use Amperity to build audience segments and send them to |destination-name| for 
 
 .. campaign-viant-dsp-api-note-end
 
-.. campaign-viant-dsp-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. campaign-viant-dsp-beta-end
-
 
 .. _campaign-viant-dsp-get-details:
 

--- a/amperity_operator/source/destination_viant_dsp.rst
+++ b/amperity_operator/source/destination_viant_dsp.rst
@@ -44,14 +44,6 @@ Use Amperity to build audience segments and send them to |destination-name| for 
 
 .. destination-viant-dsp-api-note-end
 
-.. destination-viant-dsp-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. destination-viant-dsp-beta-end
-
 
 .. _destination-viant-dsp-howitworks:
 


### PR DESCRIPTION
Strip the Beta admonition blocks (and their now-unused single-source markers) from the Viant DSP destination topic, campaign topic, and modal. To merge once the beta flag is removed from the connector in the app.