### PR TITLE
Support multiple pCLV models per database

### DIFF
--- a/amperity_operator/source/add_predicted_models.rst
+++ b/amperity_operator/source/add_predicted_models.rst
@@ -568,7 +568,7 @@ You must edit the **SELECT** statement in the **Customer 360** table to select a
    .. code-block:: sql
       :linenos:
 
-      -- Predicted Attributes from Predicted_CLV_Attributes pa
+      -- Predicted Attributes from Predicted_365d_CLV_Attributes pa
       ,pa.predicted_probability_of_transaction_next_365d AS `predicted_probability_of_transaction_next_365d`
       ,pa.predicted_order_frequency_next_365d AS `predicted_order_frequency_next_365d`
       ,pa.predicted_average_order_revenue_next_365d AS `predicted_average_order_revenue_next_365d`
@@ -582,7 +582,7 @@ You must edit the **SELECT** statement in the **Customer 360** table to select a
 
    .. code-block:: sql
 
-      LEFT JOIN Predicted_CLV_Attributes pa ON pa.amperity_id = mc.amperity_id
+      LEFT JOIN Predicted_365d_CLV_Attributes pa ON pa.amperity_id = mc.amperity_id
 
 #. Click **Next**.
 #. Click the icon or empty space in the **Icon** column to open the **Select an Icon** dialog box, after which you can choose an icon or search for additional icons on the `Font Awesome <https://fontawesome.com/v5/search>`__ |ext_link| website.

--- a/amperity_operator/source/model_churn_propensity.rst
+++ b/amperity_operator/source/model_churn_propensity.rst
@@ -334,7 +334,7 @@ For example:
        c.life_cycle
        ,p.predicted_customer_lifecycle_status
      ) AS life_cycle_final
-   FROM Predicted_CLV_Attributes AS p
+   FROM Predicted_365d_CLV_Attributes AS p
    LEFT JOIN overrides c ON p.amperity_id = c.amperity_id
 
 .. model-churn-propensity-customize-lifecycle-status-end

--- a/amperity_operator/source/model_predicted_clv.rst
+++ b/amperity_operator/source/model_predicted_clv.rst
@@ -210,6 +210,8 @@ Open the **Customer 360** page, and then select the **Predictive models** tab. T
 
 Click the **Add model** button and select **Predicted customer lifetime value (pCLV)**. In the **New model** dialog assign a name to the model and add a description.
 
+Enter a **Symbolic name**--an identifier used to name the model's :ref:`output table <model-predicted-clv-output-tables>` as **Predicted_<symbolic-name>_CLV_Attributes**. A symbolic name is required and must be unique per database. Because a database may have more than one predicted CLV model, a unique symbolic name prevents output table naming collisions. For example, a symbolic name of "365d" produces a table named **Predicted_365d_CLV_Attributes**.
+
 From the **Prediction horizon** dropdown select the number of days into the future for which predictions are made: **90 days**, **180 days**, or **365 days** (default).
 
 .. model-predicted-clv-build-create-version-end
@@ -595,7 +597,7 @@ Predicted CLV output tables
 
 .. model-predicted-clv-output-tables-start
 
-The **Predicted CLV Attributes** table has the output of predicted CLV modeling.
+The **Predicted CLV Attributes** table has the output of predicted CLV modeling. The table is named **Predicted_<symbolic-name>_CLV_Attributes**, using the :ref:`symbolic name <model-predicted-clv-build-create-version>` assigned to the model. For example, a model with a symbolic name of "365d" produces a table named **Predicted_365d_CLV_Attributes**. Because each predicted CLV model in a database uses a unique symbolic name, each model writes to its own output table.
 
 .. note:: Field names use "365d" as the default prediction horizon. If a predicted CLV model uses a different prediction horizon, such as "90 days" or "180 days", column names in the database table are not updated. The data in the table rows always matches the value for the lookback window.
 

--- a/amperity_operator/source/models.rst
+++ b/amperity_operator/source/models.rst
@@ -230,7 +230,7 @@ Extending models
 
 .. models-extend-start
 
-You can build predictive models from the **Customer 360** page. Each database that has the **Merged Customers**, **Unified Itemized Transactions**, and **Unified Transactions** tables may be configured for predictive modeling. You can only activate one churn or pCLV model per database, but you may have any number of product affinity and event propensity models.
+You can build predictive models from the **Customer 360** page. Each database that has the **Merged Customers**, **Unified Itemized Transactions**, and **Unified Transactions** tables may be configured for predictive modeling. You may have any number of pCLV, product affinity, and event propensity models.
 
 .. warning:: Even if your brand wants to use a custom transactions or transactions item table for churn and pCLV modeling, you must have tables named **Merged Customers**, **Unified Itemized Transactions**, and **Unified Transactions** in your database due to automated back-end validations.
 

--- a/amperity_operator/source/table_email_ampid_assignment.rst
+++ b/amperity_operator/source/table_email_ampid_assignment.rst
@@ -109,7 +109,7 @@ The following block shows the default list of attributes used for ranking Amperi
        ,MAX(pclv.predicted_clv_next_365d) AS predicted_clv_next_365d
      FROM email_universe univ
      LEFT JOIN Transaction_Attributes_Extended tae ON tae.amperity_id = univ.amperity_id
-     LEFT JOIN Predicted_CLV_Attributes pclv ON pclv.amperity_id = univ.amperity_id
+     LEFT JOIN Predicted_365d_CLV_Attributes pclv ON pclv.amperity_id = univ.amperity_id
      GROUP BY univ.amperity_id, univ.email, univ.update_dt
    )
 
@@ -145,7 +145,7 @@ The following block shows the default list of attributes used for ranking Amperi
 
    .. code-block:: sql
 
-      LEFT JOIN Predicted_CLV_Attributes pclv
+      LEFT JOIN Predicted_365d_CLV_Attributes pclv
       ON pclv.amperity_id = univ.amperity_id
 
    .. note:: You may include other predicted modeling tables.

--- a/amperity_operator/source/table_predicted_clv_attributes.rst
+++ b/amperity_operator/source/table_predicted_clv_attributes.rst
@@ -25,6 +25,8 @@ Predicted CLV Attributes table
 
 .. note:: The size of the **Predicted CLV Attributes** table in your tenant is based on the number of Amperity IDs.
 
+.. note:: Each predicted CLV model writes to its own output table named **Predicted_<symbolic-name>_CLV_Attributes**, using the :ref:`symbolic name <model-predicted-clv-build-create-version>` assigned to the model. For example, a model with a symbolic name of "365d" produces a table named **Predicted_365d_CLV_Attributes**. The examples on this page use **Predicted_365d_CLV_Attributes**; substitute the symbolic name for the model in your database.
+
 .. table-predicted-clv-attributes-note-end
 
 
@@ -74,7 +76,7 @@ The **Days Since Last Order** and **Historical Order Frequency Lifetime** column
         ,predicted_customer_lifetime_value_tier AS `value_tier`
         ,predicted_order_frequency_next_365d AS `predicted_orders_365`
         ,predicted_probability_of_transaction_next_365d AS `purchase_probability`
-      FROM Predicted_CLV_Attributes
+      FROM Predicted_365d_CLV_Attributes
 
 #. Hide the table from the **Visual Segment Editor** by verifying that **Show in VSE?** is unselected.
 #. Click **Activate** to update the customer 360 database with your changes.


### PR DESCRIPTION
## Summary

Documents the app change that allows more than one predicted CLV (pCLV) model per database. Each pCLV model now requires a unique **Symbolic name**, which names its output table (`Predicted_<symbolic-name>_CLV_Attributes`) to avoid table naming collisions.

## Changes

- **Removed the restriction** — `models.rst` ("Extending models") no longer states only a single pCLV model can be created per database. This was the only place site-wide that stated the restriction.
- **Documented the Symbolic name field** — added to the pCLV **Select model, create version** build step, explaining it is required, must be unique per database, and names the output table.
- **Documented output-table naming** — the pCLV output-tables section and the Predicted CLV Attributes table page now describe the `Predicted_<symbolic-name>_CLV_Attributes` convention, with each model writing to its own table.
- **Updated SQL/join examples** to use the concrete `Predicted_365d_CLV_Attributes` table name across `add_predicted_models.rst`, `model_churn_propensity.rst`, `table_predicted_clv_attributes.rst`, and `table_email_ampid_assignment.rst`.

## Notes

- The churn-per-database wording in `models.rst` was trimmed as part of this work.
- Reference/user-facing docs (`data_tables.rst`, `shared/terms.rst`) still use the friendly display name "Predicted CLV Attributes" rather than the physical table name, since those are segment/attribute contexts rather than SQL. Can surface the naming there too if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)