### PR TITLE
docs: add new az-prod-en1 egress IPs to Microsoft Azure (EU) allowlist

### DIFF
--- a/amperity_operator/source/bridge_databricks.rst
+++ b/amperity_operator/source/bridge_databricks.rst
@@ -373,7 +373,7 @@ The user who performs these actions may use the Databricks CLI or the Databricks
        * On Amazon AWS use "52.42.237.53"
        * On Amazon AWS (Canada) use "3.98.199.97"
        * On Microsoft Azure use "104.46.106.84" and "20.81.91.210"
-       * On Microsoft Azure (EU) use "20.123.127.54"
+       * On Microsoft Azure (EU) use "20.123.127.54", "4.207.101.252", and "40.127.209.91"
 
 
    * - .. image:: ../../images/steps-arrow-off-black.png

--- a/amperity_reference/source/infrastructure.rst
+++ b/amperity_reference/source/infrastructure.rst
@@ -121,7 +121,7 @@ Most connections are made directly to your Amperity tenant. Use one of the follo
 * On Amazon AWS use "52.42.237.53"
 * On Amazon AWS (Canada) use "3.98.199.97"
 * On Microsoft Azure use "104.46.106.84" for production and "20.81.91.210" for failover
-* On Microsoft Azure (EU) use "20.123.127.54"
+* On Microsoft Azure (EU) use "20.123.127.54", "4.207.101.252", and "40.127.209.91"
 
 .. send-data-to-amperity-ip-allowlists-amperity-end
 
@@ -307,4 +307,3 @@ Snowflake account locator IDs
 .. include:: ../../amperity_operator/source/bridge_snowflake.rst
    :start-after: .. bridge-snowflake-sync-amperity-configure-snowflake-account-locator-start
    :end-before: .. bridge-snowflake-sync-amperity-configure-snowflake-account-locator-end
-


### PR DESCRIPTION
## Summary

A new dedicated AKS NAT gateway was deployed for az-prod-en1 (Azure North Europe) on 2026-08-13 to resolve an Azure DDoS mitigation issue that was silently dropping packets on `20.123.127.54`. Bridge-service metadata calls now originate from two additional IPs.

Customers with Databricks IP access lists on az-prod-en1 must allowlist all three IPs:
- `20.123.127.54` (existing — keep)
- `4.207.101.252` (new)
- `40.127.209.91` (new)

**Files changed:**
- `amperity_reference/source/infrastructure.rst` — updates the `send-data-to-amperity-ip-allowlists-amperity` block (also included by `send_data.rst`, so two rendered pages update from one source change)
- `amperity_operator/source/bridge_databricks.rst` — updates requirement 6 in the "Get details" section

**Reference:** ZD#20756 (Virgin Atlantic), eng-support Slack thread 2026-08-07, infra PR #71729

## Test plan

- [ ] Verify rendered output at `docs.amperity.com/reference/infrastructure.html` shows all three Azure (EU) IPs
- [ ] Verify rendered output at `docs.amperity.com/operator/send_data.html` shows all three Azure (EU) IPs (via RST include)
- [ ] Verify rendered output at `docs.amperity.com/operator/bridge_databricks.html` shows all three Azure (EU) IPs under requirement 6