### PR TITLE
revert: remove new az-prod-en1 egress IPs from allowlist docs

### DIFF
--- a/amperity_operator/source/bridge_databricks.rst
+++ b/amperity_operator/source/bridge_databricks.rst
@@ -373,7 +373,7 @@ The user who performs these actions may use the Databricks CLI or the Databricks
        * On Amazon AWS use "52.42.237.53"
        * On Amazon AWS (Canada) use "3.98.199.97"
        * On Microsoft Azure use "104.46.106.84" and "20.81.91.210"
-       * On Microsoft Azure (EU) use "20.123.127.54", "4.207.101.252", and "40.127.209.91"
+       * On Microsoft Azure (EU) use "20.123.127.54"
 
 
    * - .. image:: ../../images/steps-arrow-off-black.png

--- a/amperity_reference/source/infrastructure.rst
+++ b/amperity_reference/source/infrastructure.rst
@@ -121,7 +121,7 @@ Most connections are made directly to your Amperity tenant. Use one of the follo
 * On Amazon AWS use "52.42.237.53"
 * On Amazon AWS (Canada) use "3.98.199.97"
 * On Microsoft Azure use "104.46.106.84" for production and "20.81.91.210" for failover
-* On Microsoft Azure (EU) use "20.123.127.54", "4.207.101.252", and "40.127.209.91"
+* On Microsoft Azure (EU) use "20.123.127.54"
 
 .. send-data-to-amperity-ip-allowlists-amperity-end
 


### PR DESCRIPTION
## Summary

Reverts the Microsoft Azure (EU) IP allowlist changes from #911. Engineering is rolling back infra PR #71729 (dedicated AKS NAT gateway for az-prod-en1) due to new issues, so the docs change that added `4.207.101.252` and `40.127.209.91` to the allowlist also needs to be reverted.

Restores both affected files to the original single-IP entry for Microsoft Azure (EU):
- `amperity_reference/source/infrastructure.rst`
- `amperity_operator/source/bridge_databricks.rst`

Ref: ZD#20756