### PR TITLE
Add az-prod aws_us_east_1 account locator (EIC61379)

### DIFF
--- a/amperity_operator/source/bridge_snowflake.rst
+++ b/amperity_operator/source/bridge_snowflake.rst
@@ -541,8 +541,8 @@ Snowflake must be configured for the correct `account locator IDs <https://docs.
      - RN08588
 
    * - az-prod
-     - azure_australiaeast
-     - MD18696
+     - aws_us_east_1
+     - EIC61379
 
    * - az-prod-en1
      - azure_australiaeast


### PR DESCRIPTION
## Summary
- Add `az-prod / aws_us_east_1 / EIC61379` to the Amperity account locator IDs table in `bridge_snowflake.rst`
- Remove a duplicate `az-prod / azure_australiaeast / MD18696` row

## Requested by
- [HALP-8640 - Re: Amperity Bridge](https://amperity.atlassian.net/browse/HALP-8640?focusedCommentId=310444)
- Customer Ticket # [20755](https://amperity.zendesk.com/agent/tickets/20755)

## Test plan
- [ ] Docs build renders the updated table