### PR TITLE
Shopify connector 48764

### DIFF
--- a/amperity_base/source/_templates/destinations.html
+++ b/amperity_base/source/_templates/destinations.html
@@ -1654,6 +1654,22 @@
     </a>
 
 
+    <a href="/operator/destination_shopify_graphql.html" class="card">
+      <div class="card-content" title="Shopify (GraphQL)">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-shopify.svg" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-shopify-dark.svg" class="card-image" />
+        </figure>
+        <div class="card-title">Shopify (GraphQL)</div>
+        <div class="card-description">
+          Send audiences to Shopify as customer tags.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/destination_smg.html" class="card">
       <div class="card-content" title="SMG">
         <figure class="light-only align-center">

--- a/amperity_base/source/_templates/sources.html
+++ b/amperity_base/source/_templates/sources.html
@@ -986,6 +986,22 @@
     </a>
 
 
+    <a href="/operator/source_shopify_graphql.html" class="card">
+      <div class="card-content" title="Shopify (GraphQL)">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-shopify.svg" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-shopify-dark.svg" class="card-image" />
+        </figure>
+        <div class="card-title">Shopify (GraphQL)</div>
+        <div class="card-description">
+          Pull customer, order, and product data from Shopify.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/source_smg.html" class="card">
       <div class="card-content" title="SMG">
         <figure class="light-only align-center">

--- a/amperity_modals/source/destination-shopify-graphql.rst
+++ b/amperity_modals/source/destination-shopify-graphql.rst
@@ -1,0 +1,83 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: Shopify (GraphQL)
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+.. |audience-primary-key| replace:: "email"
+
+
+Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. destination-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-shopify-graphql-beta-end
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**Shop name**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-shopify-shop-name-start
+   :end-before: .. credential-shopify-shop-name-end
+
+**Access token**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-shopify-access-token-start
+   :end-before: .. credential-shopify-access-token-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Audience primary key**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-audience-primary-key-start
+   :end-before: .. setting-common-audience-primary-key-end
+
+**Customer tag**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-shopify-graphql-audience-tag-start
+   :end-before: .. setting-shopify-graphql-audience-tag-end
+
+**Campaign file settings**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. campaigns-steps-campaign-settings-start
+   :end-before: .. campaigns-steps-campaign-settings-end

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -99,6 +99,7 @@ Site Index
    destination-sevenrooms
    destination-sfmc-sftp
    destination-sftp
+   destination-shopify-graphql
    destination-smg
    destination-snapchat
    destination-snowflake

--- a/amperity_operator/source/campaign_shopify_graphql.rst
+++ b/amperity_operator/source/campaign_shopify_graphql.rst
@@ -1,0 +1,358 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Shopify (GraphQL)
+.. |destination-api| replace:: Shopify GraphQL Admin API
+.. |plugin-name| replace:: "Shopify (GraphQL)"
+.. |credential-type| replace:: "shopify"
+.. |required-credentials| replace:: "Shop name" and "Access token"
+.. |audience-primary-key| replace:: "email"
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+.. |filter-the-list| replace:: "Shopify"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send campaigns to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send campaigns to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure campaigns for Shopify (GraphQL)
+
+==================================================
+Configure campaigns for Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. campaign-shopify-graphql-start
+
+Use Amperity to activate a campaign audience into |destination-name|. Build a query or segment that includes the **email** field, and then send it to |destination-name|.
+
+A Shopify segment is defined by a query rather than by a member list, so there is no list to push an audience into. Instead, Amperity activates an audience as a Shopify customer tag: it matches customers by email, applies the tag to members of the audience, and removes the tag from customers that leave the audience. In Shopify, build a customer segment on the condition that the customer tag is present -- for example, ``customer_tags CONTAINS <tag>`` -- to act on the audience.
+
+The customer tag identifies the audience, so changing the tag name sends the entire audience again under the new tag. Only the **email** match key is used -- Amperity applies the tag and does not write any other profile attributes. Each run sends only the additions and removals since the previous run, not the full audience.
+
+.. campaign-shopify-graphql-end
+
+.. campaign-shopify-graphql-api-note-start
+
+.. note:: This destination uses the `Shopify GraphQL Admin API <https://shopify.dev/docs/api/admin-graphql>`__ |ext_link|.
+
+.. campaign-shopify-graphql-api-note-end
+
+.. campaign-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. campaign-shopify-graphql-beta-end
+
+.. campaign-shopify-graphql-scope-start
+
+.. note:: Sending an audience requires the ``write_customers`` access scope on the Shopify app. Pulling data does not. A credential without this scope fails the send.
+
+.. campaign-shopify-graphql-scope-end
+
+.. campaign-shopify-graphql-existing-customers-start
+
+.. note:: Shopify must already contain a customer whose email matches an audience member. Amperity applies the tag to customers that already exist; an audience member that Shopify cannot match by email is reported as a failed row.
+
+.. campaign-shopify-graphql-existing-customers-end
+
+.. campaign-shopify-graphql-partial-failure-start
+
+.. caution:: A run can partially succeed. An individual audience member is counted as a failed row -- while the rest of the run completes -- when the member's row has no email, when no Shopify customer matches the email, when more than one Shopify customer matches the email, or when Shopify rejects the tag for that customer (for example, the customer is already at Shopify's limit of 250 tags).
+
+.. campaign-shopify-graphql-partial-failure-end
+
+.. campaign-shopify-graphql-unmatched-chunk-start
+
+.. important:: If none of the first 100 audience members match a Shopify customer, Amperity stops the send rather than reporting the entire audience as failed rows. This usually means that none of those members are customers of this store. Verify that the audience members shop with this store, and contact Amperity support if they do.
+
+.. campaign-shopify-graphql-unmatched-chunk-end
+
+.. campaign-shopify-graphql-idempotent-start
+
+.. note:: Re-running a send is safe. Applying a tag that a customer already has, or removing a tag that a customer does not have, makes no change in Shopify.
+
+.. campaign-shopify-graphql-idempotent-end
+
+.. campaign-shopify-graphql-limits-start
+
+.. note:: Amperity looks up one customer and applies or removes one tag per audience member, and paces the send to stay within Shopify's API rate limits. Time a representative audience before sending to a large store.
+
+.. campaign-shopify-graphql-limits-end
+
+
+.. _campaign-shopify-graphql-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. campaign-shopify-graphql-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **Shop name**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-shop-name-start
+             :end-before: .. credential-shopify-shop-name-end
+
+       **Access token**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-access-token-start
+             :end-before: .. credential-shopify-access-token-end
+
+       .. tip::
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-find-credentials-start
+             :end-before: .. credential-shopify-find-credentials-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Audience primary key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Customer tag**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-shopify-graphql-audience-tag-start
+             :end-before: .. setting-shopify-graphql-audience-tag-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - A campaign that is configured to use the sub-audience editor, or a one-time campaign that is configured to use a query or segment.
+
+.. campaign-shopify-graphql-get-details-end
+
+
+.. _campaign-shopify-graphql-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Shopify (GraphQL)**
+
+.. campaign-shopify-graphql-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **Shop name**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-shop-name-start
+             :end-before: .. credential-shopify-shop-name-end
+
+       **Access token**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-access-token-start
+             :end-before: .. credential-shopify-access-token-end
+
+.. campaign-shopify-graphql-credentials-steps-end
+
+
+.. _campaign-shopify-graphql-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Shopify (GraphQL)**
+
+.. campaign-shopify-graphql-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-add-destinations-start
+          :end-before: .. campaigns-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add destination
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-add-destinations-select-start
+          :end-before: .. campaigns-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-select-credential-start
+          :end-before: .. campaigns-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. campaigns-steps-test-connection-start
+             :end-before: .. campaigns-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-name-and-description-start
+          :end-before: .. campaigns-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-settings-start
+          :end-before: .. campaigns-steps-settings-end
+
+       **Audience primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Customer tag** (Required at orchestration)
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-shopify-graphql-audience-tag-start
+             :end-before: .. setting-shopify-graphql-audience-tag-end
+
+       **Campaign file settings**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. campaigns-steps-campaign-settings-start
+             :end-before: .. campaigns-steps-campaign-settings-end
+
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. campaigns-steps-business-users-start
+          :end-before: .. campaigns-steps-business-users-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. campaign-shopify-graphql-add-steps-end

--- a/amperity_operator/source/destination_shopify_graphql.rst
+++ b/amperity_operator/source/destination_shopify_graphql.rst
@@ -1,0 +1,352 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Shopify (GraphQL)
+.. |destination-api| replace:: Shopify GraphQL Admin API
+.. |plugin-name| replace:: "Shopify (GraphQL)"
+.. |credential-type| replace:: "shopify"
+.. |required-credentials| replace:: "Shop name" and "Access token"
+.. |audience-primary-key| replace:: "email"
+.. |what-send| replace:: audiences
+.. |where-send| replace:: |destination-name|
+.. |filter-the-list| replace:: "Shopify"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send audiences to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send audiences to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure destinations for Shopify (GraphQL)
+
+==================================================
+Configure destinations for Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. destination-shopify-graphql-start
+
+Use Amperity to activate an audience into |destination-name|. Build a query or segment that includes the **email** field, and then send it to |destination-name|.
+
+A Shopify segment is defined by a query rather than by a member list, so there is no list to push an audience into. Instead, Amperity activates an audience as a Shopify customer tag: it matches customers by email, applies the tag to members of the audience, and removes the tag from customers that leave the audience. In Shopify, build a customer segment on the condition that the customer tag is present -- for example, ``customer_tags CONTAINS <tag>`` -- to act on the audience.
+
+The customer tag identifies the audience, so changing the tag name sends the entire audience again under the new tag. Only the **email** match key is used -- Amperity applies the tag and does not write any other profile attributes. Each run sends only the additions and removals since the previous run, not the full audience.
+
+.. destination-shopify-graphql-end
+
+.. destination-shopify-graphql-api-note-start
+
+.. note:: This destination uses the `Shopify GraphQL Admin API <https://shopify.dev/docs/api/admin-graphql>`__ |ext_link|.
+
+.. destination-shopify-graphql-api-note-end
+
+.. destination-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-shopify-graphql-beta-end
+
+.. destination-shopify-graphql-scope-start
+
+.. note:: Sending an audience requires the ``write_customers`` access scope on the Shopify app. Pulling data does not. A credential without this scope fails the send.
+
+.. destination-shopify-graphql-scope-end
+
+.. destination-shopify-graphql-existing-customers-start
+
+.. note:: Shopify must already contain a customer whose email matches an audience member. Amperity applies the tag to customers that already exist; an audience member that Shopify cannot match by email is reported as a failed row.
+
+.. destination-shopify-graphql-existing-customers-end
+
+.. destination-shopify-graphql-partial-failure-start
+
+.. caution:: A run can partially succeed. An individual audience member is counted as a failed row -- while the rest of the run completes -- when the member's row has no email, when no Shopify customer matches the email, when more than one Shopify customer matches the email, or when Shopify rejects the tag for that customer (for example, the customer is already at Shopify's limit of 250 tags).
+
+.. destination-shopify-graphql-partial-failure-end
+
+.. destination-shopify-graphql-unmatched-chunk-start
+
+.. important:: If none of the first 100 audience members match a Shopify customer, Amperity stops the send rather than reporting the entire audience as failed rows. This usually means that none of those members are customers of this store. Verify that the audience members shop with this store, and contact Amperity support if they do.
+
+.. destination-shopify-graphql-unmatched-chunk-end
+
+.. destination-shopify-graphql-idempotent-start
+
+.. note:: Re-running a send is safe. Applying a tag that a customer already has, or removing a tag that a customer does not have, makes no change in Shopify.
+
+.. destination-shopify-graphql-idempotent-end
+
+.. destination-shopify-graphql-limits-start
+
+.. note:: Amperity looks up one customer and applies or removes one tag per audience member, and paces the send to stay within Shopify's API rate limits. Time a representative audience before sending to a large store.
+
+.. destination-shopify-graphql-limits-end
+
+
+.. _destination-shopify-graphql-get-details:
+
+Get details
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-shopify-graphql-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       **Shop name**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-shop-name-start
+             :end-before: .. credential-shopify-shop-name-end
+
+       **Access token**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-access-token-start
+             :end-before: .. credential-shopify-access-token-end
+
+       .. tip::
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-find-credentials-start
+             :end-before: .. credential-shopify-find-credentials-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration settings**
+
+       **Audience primary key**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Customer tag**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-shopify-graphql-audience-tag-start
+             :end-before: .. setting-shopify-graphql-audience-tag-end
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - A query or segment that outputs the **email** field for the audience members to send to |destination-name|.
+
+.. destination-shopify-graphql-get-details-end
+
+
+.. _destination-shopify-graphql-credentials:
+
+Configure credentials
+==================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Shopify (GraphQL)**
+
+.. destination-shopify-graphql-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       **Shop name**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-shop-name-start
+             :end-before: .. credential-shopify-shop-name-end
+
+       **Access token**
+
+          |checkmark-required| **Required**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-shopify-access-token-start
+             :end-before: .. credential-shopify-access-token-end
+
+.. destination-shopify-graphql-credentials-steps-end
+
+
+.. _destination-shopify-graphql-add:
+
+Add destination
+==================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Shopify (GraphQL)**
+
+.. destination-shopify-graphql-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add destination
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Audience primary key**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-audience-primary-key-start
+             :end-before: .. setting-common-audience-primary-key-end
+
+       **Customer tag** (Required at orchestration)
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-shopify-graphql-audience-tag-start
+             :end-before: .. setting-shopify-graphql-audience-tag-end
+
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-start
+          :end-before: .. destinations-steps-business-users-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. destination-shopify-graphql-add-steps-end

--- a/amperity_operator/source/grid_campaigns.rst
+++ b/amperity_operator/source/grid_campaigns.rst
@@ -308,6 +308,10 @@ Configure Amperity to send campaigns to any marketing workflow.
       :link-type: doc
       :link: campaign_sftp
 
+   .. grid-item-card:: Shopify (GraphQL)
+      :link-type: doc
+      :link: campaign_shopify_graphql
+
    .. grid-item-card:: SMG
       :link-type: doc
       :link: campaign_smg
@@ -428,6 +432,7 @@ Configure Amperity to send campaigns to any marketing workflow.
    SendGrid <campaign_sendgrid>
    SevenRooms <campaign_sevenrooms>
    SFTP <campaign_sftp>
+   Shopify (GraphQL) <campaign_shopify_graphql>
    SMG <campaign_smg>
    Snapchat <campaign_snapchat>
    SoundCommerce <campaign_soundcommerce>

--- a/amperity_operator/source/grid_destinations.rst
+++ b/amperity_operator/source/grid_destinations.rst
@@ -382,6 +382,10 @@ Set up connections to send data from Amperity to other marketing applications, t
       :link-type: doc
       :link: destination_sftp
 
+   .. grid-item-card:: Shopify (GraphQL)
+      :link-type: doc
+      :link: destination_shopify_graphql
+
    .. grid-item-card:: SMG
       :link-type: doc
       :link: destination_smg
@@ -533,6 +537,7 @@ Set up connections to send data from Amperity to other marketing applications, t
    SendGrid <destination_sendgrid>
    SevenRooms <destination_sevenrooms>
    SFTP <destination_sftp>
+   Shopify (GraphQL) <destination_shopify_graphql>
    SMG <destination_smg>
    Snapchat <destination_snapchat>
    SoundCommerce <destination_soundcommerce>

--- a/amperity_operator/source/source_shopify_graphql.rst
+++ b/amperity_operator/source/source_shopify_graphql.rst
@@ -1,0 +1,176 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |source-name| replace:: Shopify (GraphQL)
+.. |plugin-name| replace:: Shopify (GraphQL)
+.. |credential-type| replace:: **shopify**
+.. |source-interface| replace:: |source-name|
+.. |what-pull| replace:: customer, order, product, and location data
+.. |credential-fields| replace:: the name of the credential, a description, and the |source-name| **Shop name** and **Access token**
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to pull data from Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to pull data from Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Pull from Shopify (GraphQL)
+
+==================================================
+Pull from Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. source-shopify-graphql-context-start
+
+|source-name| pulls |what-pull| into Amperity using the `Shopify GraphQL Admin API <https://shopify.dev/docs/api/admin-graphql>`__ |ext_link|. It reads the same Shopify store as the REST-based Shopify source and can run alongside it.
+
+Select the data types to pull. Amperity creates a feed and a domain table for each selected data type. Each courier run reads records that were updated within the run's time range; because Shopify sets the updated timestamp when a record is created, records that are new to the store are included as well. Location records are the exception -- Shopify does not filter locations by an updated timestamp, so every location is read on each run.
+
+.. source-shopify-graphql-context-end
+
+.. source-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |source-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. source-shopify-graphql-beta-end
+
+.. source-shopify-graphql-steps-to-pull-start
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-overview-list-intro-start
+   :end-before: .. sources-overview-list-intro-end
+
+#. :ref:`Get details <source-shopify-graphql-get-details>`
+#. :ref:`Add courier <source-shopify-graphql-add-courier>`
+#. :ref:`Run courier <source-shopify-graphql-run-courier>`
+#. :ref:`Review feed and domain table <source-shopify-graphql-review-data>`
+#. :ref:`Add to courier group <source-shopify-graphql-add-to-courier-group>`
+
+.. source-shopify-graphql-steps-to-pull-end
+
+
+.. _source-shopify-graphql-get-details:
+
+Get details
+==================================================
+
+.. source-shopify-graphql-get-details-start
+
+|source-name| requires the following configuration details:
+
+#. The **Shop name** and **Access token** for |source-name|.
+
+   .. include:: ../../shared/credentials_settings.rst
+      :start-after: .. credential-shopify-find-credentials-start
+      :end-before: .. credential-shopify-find-credentials-end
+
+#. The data types to pull. You can select any combination of the following:
+
+   * **customer**, **customer-address**, **customer-metafield**, and **customer-tags**
+   * **order**, **order-line**, **order-line-refund**, **order-tags**, **discount-allocation**, and **discount-codes**
+   * **product**, **product-tags**, and **product-variant**
+   * **locations**
+
+#. The **Ingest strategy** (optional) that controls how Amperity reads from Shopify:
+
+   * **auto** (the default) runs a bulk export for a full historical load and paginated queries for a run that is bounded to a time range.
+   * **bulk** forces a bulk export, which is worth doing for a bounded but very large backfill.
+   * **paginated** forces paginated queries.
+
+   The **order-line-refund** data type cannot be exported in bulk. Under **auto** it is read with paginated queries automatically; when the **Ingest strategy** is set to **bulk** and **order-line-refund** is selected, the run stops with an error.
+
+.. note:: On the paginated strategy, a parent record that has more than 250 related child records -- for example, an order with more than 250 line items, or a customer with more than 250 addresses or metafields -- has the additional child records truncated. A bulk export has no such limit. Under **auto**, a run that is bounded to a time range uses the paginated strategy, so use **bulk** to read a parent that has a very large number of child records.
+
+.. tip:: Use |ext_snappass| to securely share configuration details for |source-name| between your company and your Amperity representative.
+
+.. source-shopify-graphql-get-details-end
+
+
+.. _source-shopify-graphql-add-courier:
+
+Add courier
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-courier-start
+   :end-before: .. term-courier-end
+
+**To add a courier**
+
+.. source-shopify-graphql-add-courier-start
+
+#. From the **Sources** page, click **Add Courier**. The **Add Courier** page opens.
+#. Find, and then click the icon for |plugin-name|. The **Add Courier** page opens.
+#. Enter the name of the courier. For example: "|source-name|".
+
+   From the **Credential** field, select an existing credential or select **Create a new credential**.
+
+   To add a credential, enter |credential-fields|. Click **Save**.
+
+   When finished click **Continue**.
+
+#. Under **Data types**, select the data types to pull to Amperity.
+#. Optionally, set the **Ingest strategy**.
+#. Click **Create**.
+
+   Amperity creates a feed and a domain table for each selected data type.
+
+.. source-shopify-graphql-add-courier-end
+
+
+.. _source-shopify-graphql-run-courier:
+
+Run courier manually
+==================================================
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-run-courier-start
+   :end-before: .. sources-run-courier-end
+
+**To run the courier manually**
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-run-courier-steps-start
+   :end-before: .. sources-run-courier-steps-end
+
+
+.. _source-shopify-graphql-review-data:
+
+Review feed and domain table
+==================================================
+
+.. source-shopify-graphql-review-data-start
+
+After running the |source-name| courier, a feed and domain table are created automatically for each data type that you selected. You may apply semantic tags to the fields in these tables and you may make a domain table available to Stitch, depending on your use case.
+
+The data types cover the following areas of your Shopify store:
+
+* **Customers** -- customer records and their addresses, metafields, and tags.
+* **Orders** -- orders and their line items, refunded line items, tags, discount codes, and discount allocations.
+* **Products** -- products and their variants and tags.
+* **Locations** -- store locations.
+
+The columns in each domain table mirror the corresponding table from the REST-based Shopify source, with some differences in coverage between the two connectors. Contact your Amperity representative for details about specific columns.
+
+.. source-shopify-graphql-review-data-end
+
+
+.. _source-shopify-graphql-add-to-courier-group:
+
+Add to courier group
+==================================================
+
+.. include:: ../../shared/sources.rst
+   :start-after: .. sources-add-to-courier-group-steps-start
+   :end-before: .. sources-add-to-courier-group-steps-end

--- a/amperity_operator/source/source_shopify_graphql.rst
+++ b/amperity_operator/source/source_shopify_graphql.rst
@@ -154,14 +154,12 @@ Review feed and domain table
 
 After running the |source-name| courier, a feed and domain table are created automatically for each data type that you selected. You may apply semantic tags to the fields in these tables and you may make a domain table available to Stitch, depending on your use case.
 
-The data types cover the following areas of your Shopify store:
+Each domain table's columns are the fields that Amperity reads for the corresponding Shopify object:
 
-* **Customers** -- customer records and their addresses, metafields, and tags.
-* **Orders** -- orders and their line items, refunded line items, tags, discount codes, and discount allocations.
-* **Products** -- products and their variants and tags.
-* **Locations** -- store locations.
-
-The columns in each domain table mirror the corresponding table from the REST-based Shopify source, with some differences in coverage between the two connectors. Contact your Amperity representative for details about specific columns.
+* **Customers** -- customer identity and contact details, email marketing consent, order and spend summary, and tags, along with each customer's addresses and metafields.
+* **Orders** -- order identity, financial and fulfillment status, monetary totals, currency, and timestamps, along with line items, refunded line items, tags, discount codes, and per-line discount allocations.
+* **Products** -- product identity, type, status, price range, inventory, and tags, along with each product's variants (price, inventory, weight, and options).
+* **Locations** -- store locations with their address details.
 
 .. source-shopify-graphql-review-data-end
 

--- a/amperity_operator/source/sources.rst
+++ b/amperity_operator/source/sources.rst
@@ -230,6 +230,10 @@ Set up connections for Amperity to ingest data from other tools and platforms.
       :link-type: doc
       :link: source_sftp
 
+   .. grid-item-card:: Shopify (GraphQL)
+      :link-type: doc
+      :link: source_shopify_graphql
+
    .. grid-item-card:: SMG
       :link-type: doc
       :link: source_smg
@@ -312,6 +316,7 @@ Set up connections for Amperity to ingest data from other tools and platforms.
    Salesforce Sales Cloud <source_salesforce_sales_cloud>
    SevenRooms <source_sevenrooms>
    SFTP <source_sftp>
+   Shopify (GraphQL) <source_shopify_graphql>
    SMG <source_smg>
    SoundCommerce <source_soundcommerce>
    Square <source_square>

--- a/amperity_user/source/campaign_shopify_graphql.rst
+++ b/amperity_user/source/campaign_shopify_graphql.rst
@@ -1,0 +1,155 @@
+.. https://docs.amperity.com/user/
+
+
+.. |destination-name| replace:: Shopify (GraphQL)
+.. |what-send| replace:: audiences
+.. |attributes-sent| replace:: email addresses
+
+
+.. meta::
+    :description lang=en:
+        Use segments and campaigns to send audiences from Amperity to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Use segments and campaigns to send audiences from Amperity to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Send audiences to Shopify (GraphQL)
+
+==================================================
+Send audiences to Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. include:: ../../amperity_operator/source/destination_shopify_graphql.rst
+   :start-after: .. destination-shopify-graphql-api-note-start
+   :end-before: .. destination-shopify-graphql-api-note-end
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-overview-list-intro-start
+   :end-before: .. channels-overview-list-intro-end
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-overview-note-start
+   :end-before: .. channels-overview-note-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-ask-to-configure-campaigns-start
+   :end-before: .. sendtos-ask-to-configure-campaigns-end
+
+.. channel-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. channel-shopify-graphql-beta-end
+
+
+.. _channel-shopify-graphql-build-segment:
+
+Build a segment
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-build-segment-start
+   :end-before: .. channels-build-segment-end
+
+.. admonition:: About segments that use the sub-audience editor
+
+   .. include:: ../../shared/channels.rst
+      :start-after: .. channels-build-segment-context-start
+      :end-before: .. channels-build-segment-context-end
+
+.. important::
+
+   .. include:: ../../shared/destination_settings.rst
+      :start-after: .. destinations-steps-validate-audience-start
+      :end-before: .. destinations-steps-validate-audience-end
+
+
+.. _channel-shopify-graphql-build-campaign:
+
+Add to a campaign
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-build-campaign-start
+   :end-before: .. channels-build-campaign-end
+
+.. channel-shopify-graphql-build-campaign-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step 1.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-open-page-start
+          :end-before: .. channels-build-campaign-steps-open-page-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step 2.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-destinations-start
+          :end-before: .. channels-build-campaign-steps-destinations-end
+
+       .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-destinations-note-start
+          :end-before: .. channels-build-campaign-steps-destinations-note-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step 3.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-edit-attributes-start
+          :end-before: .. channels-build-campaign-steps-edit-attributes-end
+
+       .. include:: ../../shared/channels.rst
+          :start-after: .. channels-build-campaign-steps-edit-attributes-note-start
+          :end-before: .. channels-build-campaign-steps-edit-attributes-note-end
+
+.. channel-shopify-graphql-build-campaign-steps-end
+
+
+.. _channel-shopify-graphql-configure-default-attributes:
+
+Configure default attributes
+==================================================
+
+.. include:: ../../shared/channels.rst
+   :start-after: .. channels-configure-default-attributes-start
+   :end-before: .. channels-configure-default-attributes-end
+
+.. channel-shopify-graphql-configure-default-attributes-start
+
+|destination-name| requires the **email** field, which is used to match audience members to Shopify customers.
+
+.. list-table::
+   :widths: 30 15 55
+   :header-rows: 1
+
+   * - Source attribute
+     - Required?
+     - Destination attribute
+   * - **email**
+     - Yes
+     - The email address for the customer. This field is required and is used to match the audience member to a Shopify customer. Amperity does not write any other profile attributes.
+
+.. channel-shopify-graphql-configure-default-attributes-end

--- a/amperity_user/source/destination_shopify_graphql.rst
+++ b/amperity_user/source/destination_shopify_graphql.rst
@@ -1,0 +1,127 @@
+.. https://docs.amperity.com/user/
+
+
+.. |destination-name| replace:: Shopify (GraphQL)
+.. |what-send| replace:: audiences
+
+
+.. meta::
+    :description lang=en:
+        Use orchestrations to send query results from Amperity to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Use orchestrations to send query results from Amperity to Shopify (GraphQL).
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Send query results to Shopify (GraphQL)
+
+==================================================
+Send query results to Shopify (GraphQL)
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-shopify-start
+   :end-before: .. term-shopify-end
+
+.. include:: ../../amperity_operator/source/destination_shopify_graphql.rst
+   :start-after: .. destination-shopify-graphql-api-note-start
+   :end-before: .. destination-shopify-graphql-api-note-end
+
+.. include:: ../../shared/destinations.rst
+   :start-after: .. destinations-overview-list-intro-start
+   :end-before: .. destinations-overview-list-intro-end
+
+.. sendto-shopify-graphql-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. sendto-shopify-graphql-beta-end
+
+.. sendto-shopify-graphql-steps-to-send-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step 1.
+          :align: center
+          :class: no-scaled-link
+     - :ref:`Build a query <sendto-shopify-graphql-build-query>`
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step 2.
+          :align: center
+          :class: no-scaled-link
+     - :ref:`Add orchestration <sendto-shopify-graphql-add-orchestration>`
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step 3.
+          :align: center
+          :class: no-scaled-link
+     - :ref:`Run orchestration <sendto-shopify-graphql-run-orchestration>`
+
+.. sendto-shopify-graphql-steps-to-send-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-ask-to-configure-start
+   :end-before: .. sendtos-ask-to-configure-end
+
+
+.. _sendto-shopify-graphql-build-query:
+
+Build query
+==================================================
+
+.. sendto-shopify-graphql-build-query-start
+
+Build a query that returns the **email** field for the audience members to send to |destination-name|. Amperity matches each row to a Shopify customer by email and applies the customer tag to the matching customers.
+
+The following example shows a query that returns email addresses from the **Customer 360** table:
+
+.. code-block:: sql
+
+   SELECT
+     email
+   FROM Customer_360
+
+.. note:: Shopify must already contain a customer whose email matches a row. A row that Shopify cannot match by email is reported as a failed row.
+
+.. sendto-shopify-graphql-build-query-end
+
+
+.. _sendto-shopify-graphql-add-orchestration:
+
+Add orchestration
+==================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-orchestration-start
+   :end-before: .. term-orchestration-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-add-orchestration-generic-start
+   :end-before: .. sendtos-add-orchestration-generic-end
+
+
+.. _sendto-shopify-graphql-run-orchestration:
+
+Run orchestration
+==================================================
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-start
+   :end-before: .. sendtos-run-orchestration-end
+
+.. include:: ../../shared/sendtos.rst
+   :start-after: .. sendtos-run-orchestration-steps-start
+   :end-before: .. sendtos-run-orchestration-steps-end

--- a/amperity_user/source/grid_campaigns.rst
+++ b/amperity_user/source/grid_campaigns.rst
@@ -311,6 +311,10 @@ Send campaigns to any of the following marketing applications and workflows.
       :link-type: doc
       :link: campaign_sftp
 
+   .. grid-item-card:: Shopify (GraphQL)
+      :link-type: doc
+      :link: campaign_shopify_graphql
+
    .. grid-item-card:: Snapchat
       :link-type: doc
       :link: campaign_snapchat
@@ -368,6 +372,7 @@ Send campaigns to any of the following marketing applications and workflows.
    SendGrid <campaign_sendgrid>
    SevenRooms <campaign_sevenrooms>
    SFTP <campaign_sftp>
+   Shopify (GraphQL) <campaign_shopify_graphql>
    Snapchat <campaign_snapchat>
    The Trade Desk <campaign_the_trade_desk>
    TikTok Ads <campaign_tiktok_ads>

--- a/amperity_user/source/grid_queries.rst
+++ b/amperity_user/source/grid_queries.rst
@@ -329,6 +329,10 @@ Send query results to downstream workflows and to support all of your brand's ma
       :link-type: doc
       :link: destination_sftp
 
+   .. grid-item-card:: Shopify (GraphQL)
+      :link-type: doc
+      :link: destination_shopify_graphql
+
    .. grid-item-card:: Snapchat
       :link-type: doc
       :link: destination_snapchat
@@ -602,6 +606,7 @@ The following examples show using the visual **SQL Editor** to build audiences.
    SendGrid <destination_sendgrid>
    SevenRooms <destination_sevenrooms>
    SFTP <destination_sftp>
+   Shopify (GraphQL) <destination_shopify_graphql>
    Snapchat <destination_snapchat>
    Tableau <destination_tableau>
    The Trade Desk <destination_the_trade_desk>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -2386,7 +2386,7 @@ Required. A username with access to |where-send|. This username must have approp
 
 .. credential-shopify-access-token-start
 
-.. TODO: xxxxx
+The Admin API access token that authorizes Amperity to connect to your Shopify store. Sending an audience requires the ``write_customers`` access scope on the Shopify app; pulling data does not.
 
 .. credential-shopify-access-token-end
 
@@ -2394,9 +2394,15 @@ Required. A username with access to |where-send|. This username must have approp
 
 .. credential-shopify-shop-name-start
 
-.. TODO: xxxxx
+The name of your Shopify store. This identifies the store that Amperity connects to.
 
 .. credential-shopify-shop-name-end
+
+.. credential-shopify-find-credentials-start
+
+Generate an Admin API access token by creating and installing a custom app in your Shopify store's admin. Sending an audience requires the ``write_customers`` access scope on the app; pulling data requires read access to the data types that you select.
+
+.. credential-shopify-find-credentials-end
 
 
 

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -3041,6 +3041,12 @@ The SevenRooms client tag that Amperity applies to audience members. This is the
 
 .. setting-sevenrooms-tag-name-end
 
+.. setting-shopify-graphql-audience-tag-start
+
+The Shopify customer tag that Amperity applies to audience members. Shopify customer tags are flat, so the tag is the whole audience identifier. Amperity applies this tag to customers who are in the audience and removes it from customers who leave the audience. Changing the tag name sends the entire audience again under the new tag.
+
+.. setting-shopify-graphql-audience-tag-end
+
 .. setting-sftp-about-start
 
 Secure File Transfer Protocol (SFTP) is a network protocol that provides file access, file transfer, and file management over any reliable data stream.


### PR DESCRIPTION
Documents the new shopify-graphql connector, which is bi-directional in /app/ on main (:plugin.execution/types #{:source :destination}, both beta? true / work-in-progress? false, both reachable in web-ui and verified against a live store). This supersedes the earlier decision to hold the connector as source-only WIP — the egress half and live-store verification have since landed. Both directions ship labeled Beta. The existing REST shopify connector is a separate plugin and is untouched. [INT-32]

**What's included**

Source (ingress):
- amperity_operator/source/source_shopify_graphql.rst — pull customer, order, product, and location data over the Shopify GraphQL Admin API; documents the 14 data types, the auto/bulk/paginated ingest strategies, the order-line-refund bulk restriction, and the paginated-strategy nested-record truncation.

Destination + campaign (egress) — activate an Amperity audience as a Shopify customer tag, matched by email:
- Operator destination_shopify_graphql.rst and campaign_shopify_graphql.rst
- User destination_shopify_graphql.rst (orchestrations) and campaign_shopify_graphql.rst (segments/campaigns)
- Modal amperity_modals/source/destination-shopify-graphql.rst

Shared snippets and registration:
- Filled the empty credential-shopify-{shop-name,access-token} blocks, added a credential-shopify-find-credentials note, and added the setting-shopify-graphql-audience-tag setting; reused the existing term-shopify term and connector-shopify.svg logo.
- Registered in the operator destination/campaign/source grids, the modal index, both user grids, and the base sources.html / destinations.html landing pages.

**Verification**

Every behavioral claim is grounded in /app/ (specification/shopify_graphql.cljc, shopify_graphql/{destination,source,api,error}.clj).

**Reviewer notes**

- Beta at small scale: egress has run end-to-end against a live store at only 3 rows, and no bulk ingress export has been timed. This is carried by the Beta admonitions and an egress note advising to time a representative audience before sending to a large store.
- Egress writes only the email match key (applies/removes a customer tag); it writes no other profile attributes. The tag is the external audience id, so renaming it re-sends the whole audience.
- Connector label is "Shopify (GraphQL)" to match the ::plugin/name picker string and to disambiguate from the REST "Shopify" connector. API references use Shopify's official "GraphQL Admin API" name.
- The source topic deliberately does not enumerate per-table fields or semantic tags — source.clj assigns none, so it describes the streams at a high level and notes column parity with the REST connector rather than inventing a field list.