### PR TITLE
Remove Beta designation from Roku Audience connector docs

### DIFF
--- a/amperity_modals/source/destination-roku-audience.rst
+++ b/amperity_modals/source/destination-roku-audience.rst
@@ -13,14 +13,6 @@ Roku Audience
    :start-after: .. term-roku-audience-start
    :end-before: .. term-roku-audience-end
 
-.. destination-roku-audience-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. destination-roku-audience-beta-end
-
 
 Credentials
 ==================================================

--- a/amperity_operator/source/campaign_roku_audience.rst
+++ b/amperity_operator/source/campaign_roku_audience.rst
@@ -47,14 +47,6 @@ Each campaign send uploads the entire audience to |destination-name| as a single
 
 .. campaign-roku-audience-api-note-end
 
-.. campaign-roku-audience-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. campaign-roku-audience-beta-end
-
 
 .. _campaign-roku-audience-get-details:
 

--- a/amperity_operator/source/destination_roku_audience.rst
+++ b/amperity_operator/source/destination_roku_audience.rst
@@ -47,14 +47,6 @@ Each sync uploads the entire audience to |destination-name| as a single file and
 
 .. destination-roku-audience-api-note-end
 
-.. destination-roku-audience-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. destination-roku-audience-beta-end
-
 
 .. _destination-roku-audience-get-details:
 

--- a/amperity_user/source/campaign_roku_audience.rst
+++ b/amperity_user/source/campaign_roku_audience.rst
@@ -42,15 +42,6 @@ Send audiences to Roku Audience
    :start-after: .. sendtos-ask-to-configure-campaigns-start
    :end-before: .. sendtos-ask-to-configure-campaigns-end
 
-.. channel-roku-audience-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. channel-roku-audience-beta-end
-
-
 .. _channel-roku-audience-build-segment:
 
 Build a segment

--- a/amperity_user/source/destination_roku_audience.rst
+++ b/amperity_user/source/destination_roku_audience.rst
@@ -33,14 +33,6 @@ Send query results to Roku Audience
    :start-after: .. destinations-overview-list-intro-start
    :end-before: .. destinations-overview-list-intro-end
 
-.. sendto-roku-audience-beta-start
-
-.. admonition:: Beta
-
-   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
-
-.. sendto-roku-audience-beta-end
-
 .. sendto-roku-audience-steps-to-send-start
 
 .. list-table::


### PR DESCRIPTION
## Summary
World Travel Holdings successfully validated the Roku Audience Beta connector, so the BETA designation is being lifted. This removes the five Beta admonitions (and their include markers) from the Roku Audience destination and campaign topics across the operator, user, and modal books.

Roku CAPI is a separate connector and retains its Beta label.

[INT-37]

## What's included
- operator: destination_roku_audience.rst, campaign_roku_audience.rst
- user: destination_roku_audience.rst, campaign_roku_audience.rst
- modals: destination-roku-audience.rst

## Verification
operator, user, and modals books all build clean with sphinx -W (warnings-as-errors).

## Reviewer notes
- Docs-ahead-of-code: /app/ main still declares ::plugin/beta? true in roku_audience.cljc. Do not merge until the companion /app/ PR flips the flag to false on main (and Contentful is updated). Coordinated with Kurt Chase.