### PR TITLE
Meta docs: de-conflate custom audiences vs. Conversions API + document CAPI behavior

### DIFF
--- a/amperity_api/source/_templates/searchbox.html
+++ b/amperity_api/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_api/source/_templates/searchbox.html
+++ b/amperity_api/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_base/source/_templates/advanced-search.html
+++ b/amperity_base/source/_templates/advanced-search.html
@@ -426,6 +426,19 @@
   <script>
         // Keyword to path mapping
         const KEYWORD_MAPPING = {
+          "facebook audiences": "/user/destination_meta_ads_manager.html",
+          "facebook capi": "/user/events_meta_ads_manager.html",
+          "facebook conversions api": "/user/events_meta_ads_manager.html",
+          "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+          "facebook offline conversions": "/user/events_meta_ads_manager.html",
+          "facebook offline events": "/user/events_meta_ads_manager.html",
+          "meta ads conversions api": "/user/events_meta_ads_manager.html",
+          "meta audiences": "/user/destination_meta_ads_manager.html",
+          "meta capi": "/user/events_meta_ads_manager.html",
+          "meta conversions api": "/user/events_meta_ads_manager.html",
+          "meta custom audiences": "/user/destination_meta_ads_manager.html",
+          "meta offline conversions": "/user/events_meta_ads_manager.html",
+          "meta offline events": "/user/events_meta_ads_manager.html",
           "byoc": "/operator/compute.html",
           "byos": "/operator/storage.html",
           "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_base/source/_templates/advanced-search.html
+++ b/amperity_base/source/_templates/advanced-search.html
@@ -426,6 +426,8 @@
   <script>
         // Keyword to path mapping
         const KEYWORD_MAPPING = {
+          "meta ads offline events": "/user/events_meta_ads_manager.html",
+          "meta events": "/user/events_meta_ads_manager.html",
           "facebook audiences": "/user/destination_meta_ads_manager.html",
           "facebook capi": "/user/events_meta_ads_manager.html",
           "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_base/source/_templates/searchbox.html
+++ b/amperity_base/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_base/source/_templates/searchbox.html
+++ b/amperity_base/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_guides/source/_templates/searchbox.html
+++ b/amperity_guides/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_guides/source/_templates/searchbox.html
+++ b/amperity_guides/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_modals/source/destination-meta-offline-events.rst
+++ b/amperity_modals/source/destination-meta-offline-events.rst
@@ -11,9 +11,11 @@ Meta Events
 
 .. TODO: Sync this with the updated events topics.
 
-Send events to |destination-name| to help your brand track offline conversions that result from your marketing campaigns. Events may be matched with audiences in Facebook, Facebook Messenger, Instagram, and WhatsApp.
+Send conversion events to |destination-name| using the Meta `Conversions API <https://developers.facebook.com/docs/marketing-api/conversions-api>`__ |ext_link| to measure and attribute the conversions that result from your advertising, to optimize ad delivery, and to deduplicate server-side events against browser (Pixel) events. Conversions may happen offline (such as a purchase in a physical store) or online (such as a purchase on a website).
 
-Transaction events that occurred within the previous seven days *and* contain positive values for product quantity may be sent to |destination-name| using the `Conversions API for events <https://developers.facebook.com/docs/marketing-api/conversions-api/offline-events>`__ |ext_link|.
+The Conversions API is a separate Meta product from custom audiences (Meta Ads Manager), which build targeting audiences using the Meta Marketing API.
+
+Transaction events that occurred within the previous seven days *and* contain positive values for product quantity may be sent to |destination-name| using the Conversions API.
 
 .. include:: ../../amperity_user/source/events_meta_ads_manager.rst
    :start-after: .. events-meta-ads-manager-overview-window-start

--- a/amperity_operator/source/_templates/searchbox.html
+++ b/amperity_operator/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_operator/source/_templates/searchbox.html
+++ b/amperity_operator/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_operator/source/campaign_meta_ads_manager.rst
+++ b/amperity_operator/source/campaign_meta_ads_manager.rst
@@ -38,6 +38,10 @@ This endpoint removes existing customers from an audience **without resetting yo
 
 .. campaign-meta-ads-manager-end
 
+.. include:: ../../amperity_operator/source/destination_meta_ads_manager.rst
+   :start-after: .. destination-meta-ads-manager-capi-disambiguation-start
+   :end-before: .. destination-meta-ads-manager-capi-disambiguation-end
+
 .. note::
 
    .. include:: ../../shared/destinations.rst

--- a/amperity_operator/source/destination_meta_ads_manager.rst
+++ b/amperity_operator/source/destination_meta_ads_manager.rst
@@ -39,9 +39,17 @@ This endpoint removes existing customers from an audience **without resetting yo
 
 .. destination-meta-ads-manager-end
 
+.. destination-meta-ads-manager-capi-disambiguation-start
+
+.. seealso:: Custom audiences build **targeting audiences** using the Meta Marketing API. To send **conversion events** for measurement and attribution (such as offline or website purchases), use the Meta Conversions API instead. See :doc:`events_meta_ads_manager`.
+
+.. destination-meta-ads-manager-capi-disambiguation-end
+
 .. include:: ../../shared/destination_settings.rst
    :start-after: .. setting-common-sha-256-hashed-fields-start
    :end-before: .. setting-common-sha-256-hashed-fields-end
+
+.. note:: Provide **raw** (unhashed) values for the fields that Amperity hashes. Amperity normalizes and applies SHA-256 hashing automatically before sending. Do not pre-hash these values; doing so results in double-hashing and prevents Meta from matching customers.
 
 .. note::
 

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -11,7 +11,7 @@
 .. |allow-for-what| replace:: events
 .. |allow-for-duration| replace:: up to 24 hours
 .. |attributes-sent| replace:: |destination-name| requires the **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE** attributes. The **MADID** (mobile advertising ID) attribute is optional.
-.. |hashed-fields| replace:: **email**, **phone**, **given_name**, **surname**, **state**, **city**, **postal**, **country**, **birthdate**, **gender**, and **external_id**
+.. |hashed-fields| replace:: **email**, **phone**, **given_name**, **surname**, **state**, **city**, **postal**, **country**, **birthdate**, **gender**, and **extern_id**
 
 .. meta::
     :description lang=en:
@@ -332,7 +332,7 @@ A query that returns a collection events for use in |destination-name| is simila
    :linenos:
 
    SELECT
-     c360.amperity_id AS external_id
+     c360.amperity_id AS extern_id
      ,c360.email AS email
      ,c360.phone AS phone
      ,c360.given_name AS given_name
@@ -354,7 +354,7 @@ A query that returns a collection events for use in |destination-name| is simila
    LEFT JOIN Customer_360 c360 ON uit.amperity_id = c360.amperity_id
    WHERE uit.order_datetime > (CURRENT_DATE - interval '7' day)
 
-The query **MUST** contain the following fields: **email** or **phone** and **timestamp**. For Purchase events (or when **event_name** is not specified), the query must also contain **currency** and either **quantity** and **price**, or **value**. The fields **external_id** and **order_id** are recommended. When **action_source** is not specified the default value is "physical_store".
+The query **MUST** contain the following fields: **email** or **phone** and **timestamp**. For Purchase events (or when **event_name** is not specified), the query must also contain **currency** and either **quantity** and **price**, or **value**. The fields **extern_id** and **order_id** are recommended. When **action_source** is not specified the default value is "physical_store".
 
 You may include any of the following customer profile fields to help improve match rates in |destination-name|: **given_name**, **surname**, **birthdate**, **gender**, **city**, **state**, **postal**, and **country**.
 
@@ -396,7 +396,7 @@ The following SQL shows how to send many event types stored in a table named **C
    :linenos:
 
    SELECT
-     c360.amperity_id AS external_id
+     c360.amperity_id AS extern_id
      ,c360.email AS email
      ,c360.phone AS phone
      ,events.order_id AS order_id
@@ -562,7 +562,7 @@ The fields are listed alphabetically, but may be returned by a query in any orde
              :linenos:
 
              SELECT
-               c360.amperity_id AS external_id
+               c360.amperity_id AS extern_id
                ,c360.email AS email
                ,c360.phone AS phone
                ,leads.lead_datetime AS timestamp
@@ -574,16 +574,16 @@ The fields are listed alphabetically, but may be returned by a query in any orde
              WHERE leads.lead_datetime > (CURRENT_DATE - interval '7' day)
 
 
-   * - **external_id**
+   * - **extern_id**
      - **Recommended**
 
-       The **amperity_id** field **MUST** be renamed to **external_id**.
+       The query column **MUST** be named **extern_id**. Amperity sends this value to Meta as **external_id** in the **user_data** object.
 
-       Add **external_id** to your query:
+       Add **extern_id** to your query:
 
        ::
 
-          ,c360.amperity_id AS external_id
+          ,c360.amperity_id AS extern_id
 
        .. note:: Amperity performs the same actions for the external ID when sending to the Conversions API as when sending to the Marketing API.
 

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -362,6 +362,15 @@ The query **MUST** contain the following fields: **email** or **phone** and **ti
 
 You may include any of the following customer profile fields to help improve match rates in |destination-name|: **given_name**, **surname**, **birthdate**, **gender**, **city**, **state**, **postal**, and **country**.
 
+.. LEGAL-PENDING - DO NOT PUBLISH until Legal approves the wording. Staged per Bel's
+   feedback (Slack CR2QFF327 / C0AKM7R9483). The email column typically resolves to the
+   master profile email (for example, c360.email), which reflects consent captured at the
+   profile level, not at the individual email-address level. Customers who require
+   email-level consent must shape the query to send only addresses consented at that level.
+   Draft to be finalized by Legal: "The email sent is the master profile email and is
+   consented at the profile level." When approved, convert this comment into a rendered
+   note near the email guidance.
+
 .. tip::
 
    Extend the **WHERE** clause to filter query results by purchase channel, purchase brand, purchase quantity, and to remove items that were returned or canceled.

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -362,12 +362,6 @@ The query **MUST** contain the following fields: **email** or **phone** and **ti
 
 You may include any of the following customer profile fields to help improve match rates in |destination-name|: **given_name**, **surname**, **birthdate**, **gender**, **city**, **state**, **postal**, and **country**.
 
-.. note:: The **email** sent is the master profile email and is consented at the profile level.
-
-.. TODO: above note is LEGAL-PENDING - DO NOT PUBLISH until Legal approves the wording. The email column typically resolves to the
-   master profile email (for example, c360.email), which reflects consent captured at the profile level, not at the individual email-address level. Customers who require email-level consent must
-   shape the query to send only addresses consented at that level.
-
 .. tip::
 
    Extend the **WHERE** clause to filter query results by purchase channel, purchase brand, purchase quantity, and to remove items that were returned or canceled.
@@ -593,6 +587,12 @@ The fields are listed alphabetically, but may be returned by a query in any orde
           ,c360.phone AS phone
 
        .. note:: Amperity performs the same actions for email addresses and phone numbers when sending to the Conversions API as when sending to the Marketing API.
+
+       .. note:: The **email** sent is the master profile email and is consented at the profile level.
+
+       .. TODO: above note is LEGAL-PENDING - DO NOT PUBLISH until Legal approves the wording. The email column typically resolves to the
+          master profile email (for example, c360.email), which reflects consent captured at the profile level, not at the individual email-address level. Customers who require email-level consent must
+          shape the query to send only addresses consented at that level.
 
    * - **event_name**
      - **Optional**

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -7,19 +7,17 @@
 .. |required-credentials| replace:: "refresh token"
 .. |what-send| replace:: events
 .. |where-send| replace:: |destination-name|
-.. |what-enable| replace:: **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE**
 .. |allow-for-what| replace:: events
 .. |allow-for-duration| replace:: up to 24 hours
-.. |attributes-sent| replace:: |destination-name| requires the **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE** attributes. The **MADID** (mobile advertising ID) attribute is optional.
 .. |hashed-fields| replace:: **email**, **phone**, **given_name**, **surname**, **state**, **city**, **postal**, **country**, **birthdate**, **gender**, and **extern_id**
 
 .. meta::
     :description lang=en:
-        Configure Amperity to send events to Meta Ads Manager.
+        Configure Amperity to send conversion events to Meta using the Conversions API.
 
 .. meta::
     :content class=swiftype name=body data-type=text:
-        Configure Amperity to send events to Meta Ads Manager.
+        Configure Amperity to send conversion events to Meta using the Conversions API.
 
 .. meta::
     :content class=swiftype name=title data-type=string:

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -31,7 +31,7 @@ Configure the Meta Conversions API
 
 .. events-meta-ads-manager-overview-start
 
-Send conversion events to |destination-name| using the Meta `Conversions API <https://developers.facebook.com/docs/marketing-api/conversions-api>`__ |ext_link| to measure and attribute the conversions that result from your advertising, to optimize ad delivery, and to deduplicate server-side events against browser (Pixel) events. Conversions may happen offline (such as a purchase in a physical store) or online (such as a purchase on a website).
+Send conversion events to |destination-name| using the Meta `Conversions API <https://developers.facebook.com/docs/marketing-api/conversions-api>`__ |ext_link| to measure and attribute the conversions that result from your advertising, to optimize ad delivery, and to deduplicate server-side events against browser (Pixel) events. The Conversions API is an omni-channel events feed: conversions may happen offline (such as a purchase in a physical store) or online (such as a purchase on a website).
 
 Transaction events that occurred within the previous seven days *and* contain positive values for product quantity may be sent to |destination-name| using the Conversions API.
 
@@ -39,7 +39,7 @@ Transaction events that occurred within the previous seven days *and* contain po
 
 .. events-meta-ads-manager-inproduct-name-start
 
-.. note:: In Amperity, this destination appears as **Meta Ads Offline Events** when you add a destination. It sends events using the Meta Conversions API and supports both offline and website conversions.
+.. note:: In Amperity, this destination appears as **Meta Ads Offline Events** when you add a destination. It sends events using the Meta Conversions API as an omni-channel events feed that supports both offline and website conversions.
 
 .. events-meta-ads-manager-inproduct-name-end
 

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -11,7 +11,7 @@
 .. |allow-for-what| replace:: events
 .. |allow-for-duration| replace:: up to 24 hours
 .. |attributes-sent| replace:: |destination-name| requires the **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE** attributes. The **MADID** (mobile advertising ID) attribute is optional.
-.. |hashed-fields| replace:: **EMAIL**, **PHONE**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, and **EXTERN_ID**
+.. |hashed-fields| replace:: **email**, **phone**, **given_name**, **surname**, **state**, **city**, **postal**, **country**, **birthdate**, **gender**, and **external_id**
 
 .. meta::
     :description lang=en:
@@ -23,21 +23,27 @@
 
 .. meta::
     :content class=swiftype name=title data-type=string:
-        Configure events for Meta Ads Manager
+        Configure the Meta Conversions API
 
 ==================================================
-Configure events for Meta Ads Manager
+Configure the Meta Conversions API
 ==================================================
 
 .. TODO: Sync this with the updated events topics.
 
 .. events-meta-ads-manager-overview-start
 
-Send events to |destination-name| to help your brand track offline conversions that result from your marketing campaigns. Events may be matched with audiences in Facebook, Facebook Messenger, Instagram, and WhatsApp.
+Send conversion events to |destination-name| using the Meta `Conversions API <https://developers.facebook.com/docs/marketing-api/conversions-api>`__ |ext_link| to measure and attribute the conversions that result from your advertising, to optimize ad delivery, and to deduplicate server-side events against browser (Pixel) events. Conversions may happen offline (such as a purchase in a physical store) or online (such as a purchase on a website).
 
-Transaction events that occurred within the previous seven days *and* contain positive values for product quantity may be sent to |destination-name| using the `Conversions API for events <https://developers.facebook.com/docs/marketing-api/conversions-api/offline-events>`__ |ext_link|.
+Transaction events that occurred within the previous seven days *and* contain positive values for product quantity may be sent to |destination-name| using the Conversions API.
 
 .. events-meta-ads-manager-overview-end
+
+.. events-meta-ads-manager-capi-disambiguation-start
+
+.. seealso:: The Conversions API sends **conversion events** for measurement and attribution. It is a separate Meta product from **custom audiences**, which build **targeting audiences** using the Meta Marketing API. The two are configured separately and use different settings: a **Dataset ID** for the Conversions API, and an **Account ID** with a **custom audience name** for custom audiences. To build custom audiences for targeting, see :doc:`destination_meta_ads_manager`.
+
+.. events-meta-ads-manager-capi-disambiguation-end
 
 .. events-meta-ads-manager-overview-window-start
 
@@ -56,6 +62,8 @@ Transaction events that occurred within the previous seven days *and* contain po
 .. include:: ../../shared/destination_settings.rst
    :start-after: .. setting-common-sha-256-hashed-fields-start
    :end-before: .. setting-common-sha-256-hashed-fields-end
+
+.. note:: Provide **raw** (unhashed) values for the fields that Amperity hashes. Amperity normalizes and applies SHA-256 hashing automatically before sending. Do not pre-hash these values; doing so results in double-hashing and prevents Meta from matching customers.
 
 .. _events-meta-ads-manager-get-details:
 

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -37,6 +37,12 @@ Transaction events that occurred within the previous seven days *and* contain po
 
 .. events-meta-ads-manager-overview-end
 
+.. events-meta-ads-manager-inproduct-name-start
+
+.. note:: In Amperity, this destination appears as **Meta Ads Offline Events** when you add a destination. It sends events using the Meta Conversions API and supports both offline and website conversions.
+
+.. events-meta-ads-manager-inproduct-name-end
+
 .. events-meta-ads-manager-capi-disambiguation-start
 
 .. seealso:: The Conversions API sends **conversion events** for measurement and attribution. It is a separate Meta product from **custom audiences**, which build **targeting audiences** using the Meta Marketing API. The two are configured separately and use different settings: a **Dataset ID** for the Conversions API, and an **Account ID** with a **custom audience name** for custom audiences. To build custom audiences for targeting, see :doc:`destination_meta_ads_manager`.

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -362,14 +362,11 @@ The query **MUST** contain the following fields: **email** or **phone** and **ti
 
 You may include any of the following customer profile fields to help improve match rates in |destination-name|: **given_name**, **surname**, **birthdate**, **gender**, **city**, **state**, **postal**, and **country**.
 
-.. LEGAL-PENDING - DO NOT PUBLISH until Legal approves the wording. Staged per Bel's
-   feedback (Slack CR2QFF327 / C0AKM7R9483). The email column typically resolves to the
-   master profile email (for example, c360.email), which reflects consent captured at the
-   profile level, not at the individual email-address level. Customers who require
-   email-level consent must shape the query to send only addresses consented at that level.
-   Draft to be finalized by Legal: "The email sent is the master profile email and is
-   consented at the profile level." When approved, convert this comment into a rendered
-   note near the email guidance.
+.. note:: The **email** sent is the master profile email and is consented at the profile level.
+
+.. TODO: above note is LEGAL-PENDING - DO NOT PUBLISH until Legal approves the wording. The email column typically resolves to the
+   master profile email (for example, c360.email), which reflects consent captured at the profile level, not at the individual email-address level. Customers who require email-level consent must
+   shape the query to send only addresses consented at that level.
 
 .. tip::
 
@@ -462,7 +459,7 @@ When your query includes an **order_id** column, the connector groups all rows t
 For a Purchase event, the connector sends a single **value**, resolved in this order:
 
 #. If the query returns a **value** column, that value is used as-is. Provide **value** as an order-level total.
-#. Otherwise, if the query returns **price** and **quantity**, the connector uses **price** multiplied by **quantity**. Use this only for itemized data where **price** is a per-unit price.
+#. Otherwise, if the query returns **price** and **quantity**, the connector uses **price** multiplied by **quantity**, summed across the order's line items. Use this only for itemized data where **price** is a per-unit price.
 #. Otherwise, no **value** is sent.
 
 .. warning:: When events are grouped by **order_id**, the connector keeps a single **value** for the order--the largest **value** found among the order's rows--on the assumption that every row already carries the order total. If your **value** is a per-line-item amount, only the largest line is sent and the rest of the basket is dropped. Pre-aggregate **value** to the order total before sending.

--- a/amperity_operator/source/events_meta_ads_manager.rst
+++ b/amperity_operator/source/events_meta_ads_manager.rst
@@ -431,6 +431,44 @@ Review the :ref:`Conversions API parameters <events-meta-ads-manager-conversions
 .. events-meta-ads-manager-offline-events-parameters-end
 
 
+.. _events-meta-ads-manager-how-events-built:
+
+How the connector builds events
+==================================================
+
+.. events-meta-ads-manager-how-events-built-start
+
+Before events are sent to |destination-name|, the connector transforms your query results. Understanding these transformations helps you shape a query that sends the values you expect.
+
+**Events are grouped by order**
+
+When your query includes an **order_id** column, the connector groups all rows that share an **order_id** (and **event_name**, when present) into a *single* event. Each line item in the order is listed in a **contents** array on that event, using the item's **product_id** and **quantity**. For example, a query that returns three rows for one order is sent as one event whose **contents** array lists three items--not as three events.
+
+.. note:: While **order_id** is in the query, events are always aggregated to the order. There is no way to send one event per line item without removing **order_id** from the query.
+
+   When your query does *not* include **order_id**, each row is sent as its own event.
+
+**The value sent for a purchase**
+
+For a Purchase event, the connector sends a single **value**, resolved in this order:
+
+#. If the query returns a **value** column, that value is used as-is. Provide **value** as an order-level total.
+#. Otherwise, if the query returns **price** and **quantity**, the connector uses **price** multiplied by **quantity**. Use this only for itemized data where **price** is a per-unit price.
+#. Otherwise, no **value** is sent.
+
+.. warning:: When events are grouped by **order_id**, the connector keeps a single **value** for the order--the largest **value** found among the order's rows--on the assumption that every row already carries the order total. If your **value** is a per-line-item amount, only the largest line is sent and the rest of the basket is dropped. Pre-aggregate **value** to the order total before sending.
+
+   Do not pass an order total in **price** alongside a **quantity**: the connector multiplies **price** by **quantity**, which inflates the amount reported to Meta. Use **value** for an already-computed total, and use **price** and **quantity** only when **price** is a per-unit price.
+
+**Purchases with no value are dropped**
+
+A Purchase event that resolves to no **value** is dropped before it is sent, rather than sent with a value of 0. Meta rejects a Purchase that has no value, and sending 0 instead would permanently record a zero-value conversion that cannot be removed and would distort conversion counts and value-based optimization. Dropped rows are reported as failures with an actionable message; the rest of the send is unaffected. Add a **WHERE** clause such as ``WHERE value > 0`` (or the equivalent for your revenue column) to exclude zero and negative values.
+
+.. note:: The **contents** array includes each item's **product_id** and **quantity** only. Item-level price is not currently included in **contents**.
+
+.. events-meta-ads-manager-how-events-built-end
+
+
 .. _events-meta-ads-manager-conversions:
 
 Conversions API parameters
@@ -610,11 +648,9 @@ The fields are listed alphabetically, but may be returned by a query in any orde
 
           ,ut.order_id AS order_id
 
-       .. important:: The number of rows that results from the query may not be the same as the number of events that are uploaded to |destination-name|. This depends on the table from which the order ID is returned.
+       .. important:: When **order_id** is present, the connector groups all rows that share an **order_id** (and **event_name**, when present) into a single event, whether the order ID comes from the **Unified Itemized Transactions** or the **Unified Transactions** table. The line items in each order are listed in the event's **contents** array. As a result, the number of events sent to |destination-name| is the number of distinct orders (per **event_name**), not the number of query rows.
 
-          #. Transactions from the **Unified Itemized Transactions** table group items by order ID to ensure that individual events are combined to describe a complete transaction. |destination-name| processes each item as a unique conversion. For example, an order ID with three individual items is attributed by |destination-name| as three conversions.
-
-          #. Transactions from the **Unified Transactions** table are grouped by order ID. Each unique combination of **order_id** and **event_name** is sent to |destination-name| as a single conversion. If **event_name** column is not included all rows grouped by order ID are assigned the "Purchase" event type and each **order_id** produces one conversion.
+          If **event_name** is not included, all rows grouped by **order_id** are assigned the "Purchase" event type, and each **order_id** produces one event. See :ref:`How the connector builds events <events-meta-ads-manager-how-events-built>` for how each order's **value** is resolved.
 
    * - **phone**
      - See **email**.

--- a/amperity_operator/source/grid_events.rst
+++ b/amperity_operator/source/grid_events.rst
@@ -50,7 +50,7 @@ Set up measurement of events like in-store purchases or venue check-ins.
       :link-type: doc
       :link: events_google_enhanced_conversions
 
-   .. grid-item-card:: Meta Ads Manager
+   .. grid-item-card:: Meta Conversions API
       :link-type: doc
       :link: events_meta_ads_manager
 
@@ -87,7 +87,7 @@ Set up measurement of events like in-store purchases or venue check-ins.
    Criteo <events_criteo>
    Google Analytics 4 <events_google_analytics>
    Google Enhanced Conversions <events_google_enhanced_conversions>
-   Meta Ads Manager <events_meta_ads_manager>
+   Meta Conversions API <events_meta_ads_manager>
    Microsoft Advertising offline conversions <events_microsoft_ads>
    Pinterest <events_pinterest>
    Roku Conversions API <events_roku_capi>

--- a/amperity_reference/source/_templates/searchbox.html
+++ b/amperity_reference/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_reference/source/_templates/searchbox.html
+++ b/amperity_reference/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_training/source/_templates/searchbox.html
+++ b/amperity_training/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_training/source/_templates/searchbox.html
+++ b/amperity_training/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_user/source/_templates/searchbox.html
+++ b/amperity_user/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/amperity_user/source/_templates/searchbox.html
+++ b/amperity_user/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/amperity_user/source/campaign_meta_ads_manager.rst
+++ b/amperity_user/source/campaign_meta_ads_manager.rst
@@ -45,9 +45,7 @@ A |destination-name| destination works like this:
 
 #. Build a custom audience using a segment.
 
-   .. note:: You can |sendto_meta_ads_manager_offline_events| to |destination-name| using the `Conversions API for events <https://developers.facebook.com/docs/marketing-api/conversions-api/offline-events>`__ |ext_link|.
-
-      Events are sent as a collection of transaction details that occurred within the previous seven days, after which Amperity can be configured to maintain a 7-day rolling window of those events.
+   .. seealso:: To send **conversion events** (such as offline or website purchases) for measurement and attribution, use the Meta Conversions API instead. This is a separate workflow from custom audiences. See :doc:`events_meta_ads_manager`.
 
 #. :ref:`Add that segment to a campaign <channel-meta-ads-manager-build-campaign>`, select Meta Ads Manager as a destination for at least one treatment group, and then configure the schedule for your campaign.
 #. Send that audience to Meta Ads Manager.

--- a/amperity_user/source/destination_meta_ads_manager.rst
+++ b/amperity_user/source/destination_meta_ads_manager.rst
@@ -10,11 +10,11 @@
 
 .. meta::
     :description lang=en:
-        Use orchestrations to send custom audiences and events from Amperity to Meta Ads Manager.
+        Use orchestrations to send custom audiences from Amperity to Meta Ads Manager.
 
 .. meta::
     :content class=swiftype name=body data-type=text:
-        Use orchestrations to send custom audiences and events from Amperity to Meta Ads Manager.
+        Use orchestrations to send custom audiences from Amperity to Meta Ads Manager.
 
 .. meta::
     :content class=swiftype name=title data-type=string:
@@ -30,9 +30,11 @@ You can use queries and orchestrations to build custom audiences in |destination
 
 Use |destination_meta_ads_manager_custom_audiences| in |destination-name| to advertise to customers on Facebook, Instagram, and Messenger, along with using the Meta Audience Network to extend your advertising beyond Facebook and reach new audiences on apps and mobile devices, such as WhatsApp.
 
-You may configure Amperity to send |destination_meta_ads_manager_offline_events| to |destination-name|. Events should be a set of transaction events that occurred within the previous 7 days. Events sent to |destination-name| using the `Conversions API for events <https://developers.facebook.com/docs/marketing-api/conversions-api/offline-events>`__ |ext_link| are matched with audiences in Facebook, Facebook Messenger, Instagram, and WhatsApp and ca help your brand track offline conversions for your marketing campaigns.
-
 .. sendto-meta-ads-manager-howitworks-end
+
+.. include:: ../../amperity_operator/source/destination_meta_ads_manager.rst
+   :start-after: .. destination-meta-ads-manager-capi-disambiguation-start
+   :end-before: .. destination-meta-ads-manager-capi-disambiguation-end
 
 .. image:: ../../images/sendto-meta-ads-manager.png
    :width: 600 px
@@ -188,30 +190,10 @@ and then assign this query to a destination that sends results to |destination-n
 
 .. _sendto-meta-ads-manager-build-query-offline-events:
 
-Send events
+Send conversion events (Conversions API)
 --------------------------------------------------
 
-.. include:: ../../amperity_user/source/events_meta_ads_manager.rst
-   :start-after: .. events-meta-ads-manager-overview-start
-   :end-before: .. events-meta-ads-manager-overview-end
-
-.. include:: ../../amperity_user/source/events_meta_ads_manager.rst
-   :start-after: .. events-meta-ads-manager-overview-window-start
-   :end-before: .. events-meta-ads-manager-overview-window-end
-
-.. include:: ../../amperity_user/source/events_meta_ads_manager.rst
-   :start-after: .. events-meta-ads-manager-allowfor-start
-   :end-before: .. events-meta-ads-manager-allowfor-end
-
-.. include:: ../../amperity_user/source/events_meta_ads_manager.rst
-   :start-after: .. events-meta-ads-manager-offline-events-build-query-start
-   :end-before: .. events-meta-ads-manager-offline-events-build-query-end
-
-.. destination-meta-ads-manager-offline-events-parameters-start
-
-Review the :ref:`Conversions API parameters <destination-meta-ads-manager-conversion-api-parameters>` section for detailed information about the columns that should be returned by your query.
-
-.. destination-meta-ads-manager-offline-events-parameters-end
+To send conversion events (such as offline or website purchases) for measurement and attribution, use the Meta Conversions API. This is a separate workflow from custom audiences, with its own settings and query requirements. See :doc:`events_meta_ads_manager`.
 
 
 .. _sendto-meta-ads-manager-add-orchestration:
@@ -264,13 +246,3 @@ Facebook Marketing API keys
 .. include:: ../../amperity_operator/source/destination_meta_ads_manager.rst
    :start-after: .. destination-meta-ads-manager-api-keys-start
    :end-before: .. destination-meta-ads-manager-api-keys-end
-
-
-.. _destination-meta-ads-manager-conversion-api-parameters:
-
-Conversions API parameters
-==================================================
-
-.. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
-   :start-after: .. events-meta-ads-manager-conversion-api-parameters-start
-   :end-before: .. events-meta-ads-manager-conversion-api-parameters-end

--- a/amperity_user/source/events_meta_ads_manager.rst
+++ b/amperity_user/source/events_meta_ads_manager.rst
@@ -73,6 +73,16 @@ Review the :ref:`Conversions API parameters <events-meta-ads-manager-conversions
 
 .. events-meta-ads-manager-offline-events-parameters-end
 
+
+.. _events-meta-ads-manager-how-events-built:
+
+How the connector builds events
+==================================================
+
+.. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
+   :start-after: .. events-meta-ads-manager-how-events-built-start
+   :end-before: .. events-meta-ads-manager-how-events-built-end
+
 .. important::
 
    .. include:: ../../shared/destination_settings.rst

--- a/amperity_user/source/events_meta_ads_manager.rst
+++ b/amperity_user/source/events_meta_ads_manager.rst
@@ -19,15 +19,19 @@
 
 .. meta::
     :content class=swiftype name=title data-type=string:
-        Send events to Meta Ads Manager
+        Send events to the Meta Conversions API
 
 ==================================================
-Send events to Meta Ads Manager
+Send events to the Meta Conversions API
 ==================================================
 
 .. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
    :start-after: .. events-meta-ads-manager-overview-start
    :end-before: .. events-meta-ads-manager-overview-end
+
+.. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
+   :start-after: .. events-meta-ads-manager-capi-disambiguation-start
+   :end-before: .. events-meta-ads-manager-capi-disambiguation-end
 
 .. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
    :start-after: .. events-meta-ads-manager-overview-window-start

--- a/amperity_user/source/events_meta_ads_manager.rst
+++ b/amperity_user/source/events_meta_ads_manager.rst
@@ -28,6 +28,10 @@ Send events to the Meta Conversions API
    :end-before: .. events-meta-ads-manager-overview-end
 
 .. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
+   :start-after: .. events-meta-ads-manager-inproduct-name-start
+   :end-before: .. events-meta-ads-manager-inproduct-name-end
+
+.. include:: ../../amperity_operator/source/events_meta_ads_manager.rst
    :start-after: .. events-meta-ads-manager-capi-disambiguation-start
    :end-before: .. events-meta-ads-manager-capi-disambiguation-end
 

--- a/amperity_user/source/events_meta_ads_manager.rst
+++ b/amperity_user/source/events_meta_ads_manager.rst
@@ -3,19 +3,17 @@
 
 .. |destination-name| replace:: Meta Ads Manager
 .. |what-send| replace:: events
-.. |what-enable| replace:: **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE**
-.. |allow-for-what| replace:: audiences
+.. |allow-for-what| replace:: events
 .. |allow-for-duration| replace:: up to 24 hours
-.. |attributes-sent| replace:: |destination-name| requires the **EXTERN_ID**, **EMAIL**, **FN**, **LN**, **ST**, **CT**, **ZIP**, **COUNTRY**, **BIRTH**, **GEN**, **MADID**, and **PHONE** attributes. The **MADID** (mobile advertising ID) attribute is optional.
 
 
 .. meta::
     :description lang=en:
-        Send events from Amperity to Meta Ads Manager.
+        Send conversion events from Amperity to Meta using the Conversions API.
 
 .. meta::
     :content class=swiftype name=body data-type=text:
-        Send events from Amperity to Meta Ads Manager.
+        Send conversion events from Amperity to Meta using the Conversions API.
 
 .. meta::
     :content class=swiftype name=title data-type=string:

--- a/amperity_user/source/grid_events.rst
+++ b/amperity_user/source/grid_events.rst
@@ -59,7 +59,7 @@ Events
       :link-type: ref
       :link: destination-klaviyo-customer-profile-parameters
 
-   .. grid-item-card:: Meta Ads Manager
+   .. grid-item-card:: Meta Conversions API
       :link-type: doc
       :link: events_meta_ads_manager
 
@@ -102,7 +102,7 @@ Events
    Criteo <events_criteo>
    Google Ads <events_google_enhanced_conversions>
    Google Analytics 4 <events_google_analytics>
-   Meta Ads Manager <events_meta_ads_manager>
+   Meta Conversions API <events_meta_ads_manager>
    Microsoft Advertising offline conversions <events_microsoft_ads>
    Pinterest <events_pinterest>
    Roku Conversions API <events_roku_capi>

--- a/contributing/source/_templates/searchbox.html
+++ b/contributing/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/contributing/source/_templates/searchbox.html
+++ b/contributing/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/legacy/source/_templates/searchbox.html
+++ b/legacy/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/legacy/source/_templates/searchbox.html
+++ b/legacy/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/legions/source/_templates/searchbox.html
+++ b/legions/source/_templates/searchbox.html
@@ -237,6 +237,19 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "facebook audiences": "/user/destination_meta_ads_manager.html",
+      "facebook capi": "/user/events_meta_ads_manager.html",
+      "facebook conversions api": "/user/events_meta_ads_manager.html",
+      "facebook custom audiences": "/user/destination_meta_ads_manager.html",
+      "facebook offline conversions": "/user/events_meta_ads_manager.html",
+      "facebook offline events": "/user/events_meta_ads_manager.html",
+      "meta ads conversions api": "/user/events_meta_ads_manager.html",
+      "meta audiences": "/user/destination_meta_ads_manager.html",
+      "meta capi": "/user/events_meta_ads_manager.html",
+      "meta conversions api": "/user/events_meta_ads_manager.html",
+      "meta custom audiences": "/user/destination_meta_ads_manager.html",
+      "meta offline conversions": "/user/events_meta_ads_manager.html",
+      "meta offline events": "/user/events_meta_ads_manager.html",
       "byoc": "/operator/compute.html",
       "byos": "/operator/storage.html",
       "crt": "/reference/glossary.html#c-campaign-recipients-table",

--- a/legions/source/_templates/searchbox.html
+++ b/legions/source/_templates/searchbox.html
@@ -237,6 +237,8 @@
   (function() {
     // Keyword to path mapping
     const KEYWORD_MAPPING = {
+      "meta ads offline events": "/user/events_meta_ads_manager.html",
+      "meta events": "/user/events_meta_ads_manager.html",
       "facebook audiences": "/user/destination_meta_ads_manager.html",
       "facebook capi": "/user/events_meta_ads_manager.html",
       "facebook conversions api": "/user/events_meta_ads_manager.html",

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -4302,6 +4302,15 @@ Meta Ads Manager is a unified ad creation tool that your brand can use to create
 .. term-meta-ads-manager-end
 
 
+**Meta Conversions API**
+
+.. term-meta-conversions-api-start
+
+The Meta Conversions API (CAPI) lets your brand send conversion events — such as purchases, leads, and sign-ups — to Meta from your server. Meta uses these events for measurement and attribution, to optimize ad delivery, and to deduplicate server-side events against browser (Pixel) events. It is a separate product from Meta custom audiences, which build targeting audiences.
+
+.. term-meta-conversions-api-end
+
+
 **metrics** concept, as exists for the Metrics tab
 
 .. term-metrics-start


### PR DESCRIPTION
Addresses feedback that the Meta docs conflate two distinct Meta
products: custom audiences (Marketing API, /app/ connector `facebook`) and the
Conversions API / CAPI (/app/ connector `meta-offline-events`). They are two
separate connectors that share only an OAuth credential. The docs were already
split into destination_* (audiences) and events_* (CAPI) stems, so this cleans
up the cross-contamination between them and documents what the CAPI connector
actually does. Stems and URLs are unchanged. 

> [!NOTE]
> Draft — not for publish yet. One item is gated on Legal (see "Gated on Legal"
> below) and a few product decisions are open (see "Open decisions"). Please
> review, but hold the merge until those are resolved.

## What's included

**De-conflation**
- Custom audiences pages now cover targeting only; removed the inlined CAPI
  "Send events" and "Conversions API parameters" sections and replaced them with
  a cross-link to the Conversions API page.
- Conversions API pages reframed around measurement, attribution, optimization,
  and Pixel dedup, covering offline and website conversions (described as an
  omni-channel events feed, per Bel) instead of "offline conversions" only.
- Added "this vs. that" seealso disambiguation on both product sides, a new
  "Meta Conversions API" glossary term, and an on-page callout noting the
  destination appears in Amperity as "Meta Ads Offline Events".

**What the connector does (new)**
- New "How the connector builds events" section on both CAPI pages, describing
  the transformations so operators can shape queries that send the values they
  expect:
  - Per-order grouping: when `order_id` is present, all rows sharing it (and
    `event_name`) become one event, with line items in a `contents` array;
    without `order_id`, one event per row.
  - Value resolution: `value` used as-is (provide an order total); else
    `price` x `quantity` (unit price only). When grouped, the largest value
    among the order's rows is kept, so per-line values must be pre-aggregated
    or basket lines are dropped; passing an order total as `price` x `quantity`
    inflates the amount reported to Meta.
  - Purchases with no value are dropped (not sent as 0) and reported as
    failures; add `WHERE value > 0`.
  - `contents` carries `product_id` and `quantity` only; item-level price is
    not currently sent.
- Corrected the misleading `order_id` note in the parameters table (it implied
  grouping differs by source table, UIT vs UT; grouping depends only on the
  `order_id` column).

**Correctness (vs /app/)**
- Fixed the CAPI id column name: the connector recognizes `extern_id` (sent to
  Meta as `external_id`); a column named `external_id` is silently dropped. Docs
  previously told users to output `external_id`. Confirmed against
  `meta-offline-events` `destination.clj`/`transforms.clj` and plugin tests.
- Fixed the CAPI hashed-fields list to the lowercase query column names and
  added a raw-values / do-not-pre-hash note.

**Findability**
- Relabeled the Meta event grid cards to "Meta Conversions API" (URLs unchanged)
  so they no longer collide with the audiences card.
- Added keyword search pins (across all 11 search templates) routing audiences
  vs. CAPI queries, including the in-product names "Meta Ads Offline Events" and
  "Meta Events".

**Hygiene**
- Removed unused audience-only substitution tokens from the CAPI pages and
  updated the meta descriptions.

Verification: strict Sphinx build (`-W`) clean across operator, user, modals, and
legacy.

## Gated on Legal (do not publish as-is)
A consent caveat is **staged as a non-rendering source comment** on the CAPI page
(`.. LEGAL-PENDING`), so it appears in this diff but does not publish. Per Bel,
the email column typically resolves to the master profile email (`c360.email`),
consented at the profile level rather than the email-address level, which
surprised an Australian customer. Legal to finalize the wording; then convert the
comment into a rendered note.

## Open decisions (product, tracked separately)
- Rename the connector from "Meta Ads Offline Events" (now inaccurate — it
  supports website events too) to "Meta Conversions API"? Docs currently bridge
  this with on-page disambiguation and search pins.
- Keep `extern_id`, or change the connector to accept the friendlier
  `external_id`? Docs now match current code either way in the near term.
- Add `item_price` to the itemized `contents` array (needed by Coles)?
- Confirm the `MAX(value)` per-order behavior is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
