### PR TITLE
Add Beta admonition to Iterable connector docs

### DIFF
--- a/amperity_modals/source/destination-iterable.rst
+++ b/amperity_modals/source/destination-iterable.rst
@@ -14,6 +14,14 @@ Iterable
    :start-after: .. term-iterable-start
    :end-before: .. term-iterable-end
 
+.. destination-iterable-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-iterable-beta-end
+
 
 Credentials
 ==================================================

--- a/amperity_operator/source/campaign_iterable.rst
+++ b/amperity_operator/source/campaign_iterable.rst
@@ -40,6 +40,14 @@ Use Amperity to build campaigns that send audiences to |destination-name|. Confi
 
 .. campaign-iterable-end
 
+.. campaign-iterable-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. campaign-iterable-beta-end
+
 
 .. _campaign-iterable-prerequisites:
 

--- a/amperity_operator/source/destination_iterable.rst
+++ b/amperity_operator/source/destination_iterable.rst
@@ -46,6 +46,14 @@ Use Amperity to manage audience lists in |destination-name|. Build a query using
 
 .. destination-iterable-api-note-end
 
+.. destination-iterable-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-iterable-beta-end
+
 
 .. _destination-iterable-get-details:
 

--- a/amperity_user/source/campaign_iterable.rst
+++ b/amperity_user/source/campaign_iterable.rst
@@ -43,6 +43,14 @@ Send audiences to Iterable
    :start-after: .. sendtos-ask-to-configure-campaigns-start
    :end-before: .. sendtos-ask-to-configure-campaigns-end
 
+.. channel-iterable-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. channel-iterable-beta-end
+
 
 .. _channel-iterable-build-segment:
 

--- a/amperity_user/source/destination_iterable.rst
+++ b/amperity_user/source/destination_iterable.rst
@@ -33,6 +33,14 @@ Send query results to Iterable
    :start-after: .. destinations-overview-list-intro-start
    :end-before: .. destinations-overview-list-intro-end
 
+.. sendto-iterable-beta-start
+
+.. admonition:: Beta
+
+   The |destination-name| connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. sendto-iterable-beta-end
+
 #. :ref:`Build a query <sendto-iterable-build-query>`
 #. :ref:`Add orchestration <sendto-iterable-add-orchestration>`
 #. :ref:`Run orchestration <sendto-iterable-run-orchestration>`


### PR DESCRIPTION
Adds a Beta admonition to all Iterable connector topics (destination and campaign, across the operator, user, and modal books) ahead of the Iterable Beta launch.

Reviewer note: /app/ currently has the Iterable connector at ::plugin/work-in-progress? true with no ::plugin/beta? flag (pre-Beta, hidden from the picker). This is docs-ahead-of-code; hold merge until the companion /app/ change flips work-in-progress? to false and sets beta? true.