### PR TITLE
Eagle eye connector 48764

### DIFF
--- a/amperity_base/source/_templates/destinations.html
+++ b/amperity_base/source/_templates/destinations.html
@@ -697,6 +697,22 @@
     </a>
 
 
+    <a href="/operator/destination_eagle_eye.html" class="card">
+      <div class="card-content" title="Eagle Eye">
+        <figure class="light-only align-center">
+          <img src="/_static/connector-eagle-eye.svg" class="card-image" />
+        </figure>
+        <figure class="dark-only align-center">
+          <img src="/_static/connector-eagle-eye.svg" class="card-image" />
+        </figure>
+        <div class="card-title">Eagle Eye</div>
+        <div class="card-description">
+          Manage loyalty wallets in the Eagle Eye AIR platform from Amperity segments.
+        </div>
+      </div>
+    </a>
+
+
     <a href="/operator/destination_epsilon_abacus.html" class="card">
       <div class="card-content" title="Epsilon Abacus">
         <figure class="light-only align-center">

--- a/amperity_modals/source/destination-eagle-eye.rst
+++ b/amperity_modals/source/destination-eagle-eye.rst
@@ -1,0 +1,94 @@
+.. /downloads/markdown/
+
+
+.. |destination-name| replace:: Eagle Eye
+.. |what-send| replace:: loyalty identities
+.. |where-send| replace:: loyalty wallets in the |destination-name| AIR platform
+
+
+Eagle Eye
+==================================================
+
+Send |what-send| from Amperity into |where-send|, performing one wallet operation for each person on every run. The **Wallet operation** setting selects what each row does — create, update, state change, suspend, activate, terminate, or delete — and a send performs a single operation for the entire run.
+
+.. admonition:: Beta
+
+   The Eagle Eye connector is currently in beta. Contact your Amperity representative to learn more.
+
+
+Credentials
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-common-name-and-description-start
+   :end-before: .. credential-common-name-and-description-end
+
+**Client ID**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-eagle-eye-client-id-start
+   :end-before: .. credential-eagle-eye-client-id-end
+
+**Client secret**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-eagle-eye-client-secret-start
+   :end-before: .. credential-eagle-eye-client-secret-end
+
+**API URL**
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-eagle-eye-api-url-start
+   :end-before: .. credential-eagle-eye-api-url-end
+
+
+Settings
+==================================================
+
+**Name and description**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-name-and-description-start
+   :end-before: .. setting-common-name-and-description-end
+
+**Business user access**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-allow-start
+   :end-before: .. setting-common-business-user-access-allow-end
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-business-user-access-restrict-pii-start
+   :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+**Identity type**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-eagle-eye-identity-type-start
+   :end-before: .. setting-eagle-eye-identity-type-end
+
+**Wallet type**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-eagle-eye-default-wallet-type-start
+   :end-before: .. setting-eagle-eye-default-wallet-type-end
+
+**Wallet state**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-eagle-eye-default-wallet-state-start
+   :end-before: .. setting-eagle-eye-default-wallet-state-end
+
+**Wallet operation**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-eagle-eye-operation-start
+   :end-before: .. setting-eagle-eye-operation-end
+
+**Wallet state**
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-eagle-eye-wallet-state-start
+   :end-before: .. setting-eagle-eye-wallet-state-end

--- a/amperity_modals/source/index.rst
+++ b/amperity_modals/source/index.rst
@@ -46,6 +46,7 @@ Site Index
    destination-dynamic-yield-customer-profiles
    destination-dynamics-365-marketing
    destination-dynamics
+   destination-eagle-eye
    destination-eloqua
    destination-emarsys
    destination-epsilon-abacus

--- a/amperity_operator/source/destination_eagle_eye.rst
+++ b/amperity_operator/source/destination_eagle_eye.rst
@@ -1,0 +1,416 @@
+.. https://docs.amperity.com/operator/
+
+
+.. |destination-name| replace:: Eagle Eye
+.. |plugin-name| replace:: "Eagle Eye"
+.. |credential-type| replace:: "eagle-eye"
+.. |required-credentials| replace:: "Client ID", "Client secret", and "API URL"
+.. |what-send| replace:: loyalty identities
+.. |where-send| replace:: loyalty wallets in the |destination-name| AIR platform
+.. |filter-the-list| replace:: "eag"
+
+
+.. meta::
+    :description lang=en:
+        Configure Amperity to send loyalty identities to wallets in the Eagle Eye AIR platform.
+
+.. meta::
+    :content class=swiftype name=body data-type=text:
+        Configure Amperity to send loyalty identities to wallets in the Eagle Eye AIR platform.
+
+.. meta::
+    :content class=swiftype name=title data-type=string:
+        Configure destinations for Eagle Eye
+
+====================================================
+Configure destinations for Eagle Eye
+====================================================
+
+.. include:: ../../shared/terms.rst
+   :start-after: .. term-eagle-eye-start
+   :end-before: .. term-eagle-eye-end
+
+.. destination-eagle-eye-start
+
+The Eagle Eye connector sends |what-send| from Amperity into |where-send|, performing one wallet operation for each person on every run.
+
+Each row in the query results is one wallet operation, addressed by the person's loyalty identity. There is no audience or list concept: Amperity does not keep a list in sync on the Eagle Eye side, it performs the configured operation for each person each time it runs. Amperity sends every row in the query results on each run; there is no incremental sync.
+
+Two columns are sent. The **identity_value** column (required) is the person's loyalty identity in Eagle Eye — a loyalty card number, email, or whatever identity type your company unit is configured for — and is the value every operation is addressed by. The **friendly_name** column (optional) is a human-readable label for the wallet: the create operation applies it to a new wallet when it is present, and the update operation exists to change it and requires it. Column names are matched without regard to capitalization, and values are sent to Eagle Eye as they appear in the query results.
+
+.. destination-eagle-eye-end
+
+.. destination-eagle-eye-api-note-start
+
+.. note:: This destination uses the `Eagle Eye AIR Wallet API <https://developer.eagleeye.com/docs/wallets-1>`__ |ext_link|.
+
+.. destination-eagle-eye-api-note-end
+
+.. destination-eagle-eye-beta-start
+
+.. admonition:: Beta
+
+   The Eagle Eye connector is currently in beta. Contact your Amperity representative to learn more.
+
+.. destination-eagle-eye-beta-end
+
+.. destination-eagle-eye-prereq-start
+
+.. important:: Eagle Eye provisions your API credentials and configures each company unit. Before you configure the destination, get the Client ID, Client secret, and regional API URL from your Eagle Eye account manager, and confirm the **Identity type** name your unit uses and the behavioral **state** values your unit accepts. A state value your unit does not recognize is rejected.
+
+.. note:: The Eagle Eye Wallet API has no bulk endpoint, so Amperity sends one request per person. Amperity paces requests at about five requests per second — an Amperity-side default, not a limit published by Eagle Eye — so a large send can take a long time (for example, a send of 100,000 people runs for several hours).
+
+.. destination-eagle-eye-prereq-end
+
+
+.. _destination-eagle-eye-operations:
+
+Wallet operations
+====================================================
+
+.. destination-eagle-eye-operations-start
+
+The **Wallet operation** setting selects what each row does, and a send performs a single operation for the entire run. You choose the operation, and the state used by state-change, when you configure the orchestration that sends to this destination.
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Operation
+     - What it does
+   * - **create**
+     - Provisions a wallet for each person and attaches their loyalty identity. This is the default. If the ``friendly_name`` column is present, its value is set as the new wallet's label. A person who already has a wallet is recovered rather than duplicated, so re-sending the same query results is safe.
+   * - **update**
+     - Changes a wallet's friendly name. Requires the ``friendly_name`` column.
+   * - **state-change**
+     - Changes a wallet's behavioral state. Requires the **Wallet state** setting.
+   * - **suspend**
+     - Temporarily halts a wallet's activity. Reversible with **activate**.
+   * - **activate**
+     - Returns a suspended or inactive wallet to service.
+   * - **terminate**
+     - Permanently closes a wallet. This is the path for consent-driven opt-out. It cannot be undone, and Eagle Eye rejects any later change to a terminated wallet.
+   * - **delete**
+     - Removes a wallet. Intended for cleaning up test data rather than for consent requests.
+
+Every operation other than **create** first looks up the person's existing wallet by their identity value. A person with no wallet yet is reported as a failed row and the run continues.
+
+.. destination-eagle-eye-operations-end
+
+
+.. _destination-eagle-eye-get-details:
+
+Get details
+====================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-get-details-start
+   :end-before: .. setting-common-get-details-end
+
+.. destination-eagle-eye-get-details-table-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 1.
+          :align: center
+          :class: no-scaled-link
+     - **Credential settings**
+
+       |checkmark-required| **Required**
+
+       All three credential fields are required. No call can be made without them.
+
+       **Client ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-client-id-start
+             :end-before: .. credential-eagle-eye-client-id-end
+
+       **Client secret**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-client-secret-start
+             :end-before: .. credential-eagle-eye-client-secret-end
+
+       **API URL**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-api-url-start
+             :end-before: .. credential-eagle-eye-api-url-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 2.
+          :align: center
+          :class: no-scaled-link
+     - **Required configuration setting**
+
+       **Identity type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-identity-type-start
+             :end-before: .. setting-eagle-eye-identity-type-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 3.
+          :align: center
+          :class: no-scaled-link
+     - **Optional destination settings**
+
+       **Wallet type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-default-wallet-type-start
+             :end-before: .. setting-eagle-eye-default-wallet-type-end
+
+       **Wallet state**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-default-wallet-state-start
+             :end-before: .. setting-eagle-eye-default-wallet-state-end
+
+
+   * - .. image:: ../../images/steps-check-off-black.png
+          :width: 60 px
+          :alt: Detail 4.
+          :align: center
+          :class: no-scaled-link
+     - **Orchestration settings**
+
+       These are chosen for each orchestration that sends to this destination, not on the destination itself.
+
+       **Wallet operation**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-operation-start
+             :end-before: .. setting-eagle-eye-operation-end
+
+       **Wallet state**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-wallet-state-start
+             :end-before: .. setting-eagle-eye-wallet-state-end
+
+
+.. destination-eagle-eye-get-details-end
+
+
+.. _destination-eagle-eye-credentials:
+
+Configure credentials
+====================================================
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-configure-first-start
+   :end-before: .. credential-configure-first-end
+
+.. include:: ../../shared/credentials_settings.rst
+   :start-after: .. credential-snappass-start
+   :end-before: .. credential-snappass-end
+
+**To configure credentials for Eagle Eye**
+
+.. destination-eagle-eye-credentials-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-add-credential-start
+          :end-before: .. credential-steps-add-credential-end
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-select-type-start
+          :end-before: .. credential-steps-select-type-end
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/credentials_settings.rst
+          :start-after: .. credential-steps-settings-intro-start
+          :end-before: .. credential-steps-settings-intro-end
+
+       |checkmark-required| **Required**
+
+       All three credential fields are required.
+
+       **Client ID**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-client-id-start
+             :end-before: .. credential-eagle-eye-client-id-end
+
+       **Client secret**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-client-secret-start
+             :end-before: .. credential-eagle-eye-client-secret-end
+
+       **API URL**
+
+          .. include:: ../../shared/credentials_settings.rst
+             :start-after: .. credential-eagle-eye-api-url-start
+             :end-before: .. credential-eagle-eye-api-url-end
+
+.. destination-eagle-eye-credentials-steps-end
+
+
+.. _destination-eagle-eye-add:
+
+Add destination
+====================================================
+
+.. include:: ../../shared/destination_settings.rst
+   :start-after: .. setting-common-sandbox-recommendation-start
+   :end-before: .. setting-common-sandbox-recommendation-end
+
+**To add a destination for Eagle Eye**
+
+.. destination-eagle-eye-add-steps-start
+
+.. list-table::
+   :widths: 10 90
+   :header-rows: 0
+
+   * - .. image:: ../../images/steps-01.png
+          :width: 60 px
+          :alt: Step one.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-start
+          :end-before: .. destinations-steps-add-destinations-end
+
+       .. image:: ../../images/mockup-destinations-add-01-select-destination-common.png
+          :width: 380 px
+          :alt: Add
+          :align: left
+          :class: no-scaled-link
+
+       .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-add-destinations-select-start
+          :end-before: .. destinations-steps-add-destinations-select-end
+
+
+   * - .. image:: ../../images/steps-02.png
+          :width: 60 px
+          :alt: Step two.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-select-credential-start
+          :end-before: .. destinations-steps-select-credential-end
+
+       .. tip::
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. destinations-steps-test-connection-start
+             :end-before: .. destinations-steps-test-connection-end
+
+
+   * - .. image:: ../../images/steps-03.png
+          :width: 60 px
+          :alt: Step three.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-name-and-description-start
+          :end-before: .. destinations-steps-name-and-description-end
+
+       .. admonition:: Configure business user access
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-allow-start
+             :end-before: .. setting-common-business-user-access-allow-end
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-common-business-user-access-restrict-pii-start
+             :end-before: .. setting-common-business-user-access-restrict-pii-end
+
+
+   * - .. image:: ../../images/steps-04.png
+          :width: 60 px
+          :alt: Step four.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-settings-start
+          :end-before: .. destinations-steps-settings-end
+
+       **Identity type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-identity-type-start
+             :end-before: .. setting-eagle-eye-identity-type-end
+
+       **Wallet type**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-default-wallet-type-start
+             :end-before: .. setting-eagle-eye-default-wallet-type-end
+
+       **Wallet state**
+
+          .. include:: ../../shared/destination_settings.rst
+             :start-after: .. setting-eagle-eye-default-wallet-state-start
+             :end-before: .. setting-eagle-eye-default-wallet-state-end
+
+   * - .. image:: ../../images/steps-05.png
+          :width: 60 px
+          :alt: Step five.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-business-users-orchestration-only-start
+          :end-before: .. destinations-steps-business-users-orchestration-only-end
+
+
+   * - .. image:: ../../images/steps-06.png
+          :width: 60 px
+          :alt: Step six.
+          :align: center
+          :class: no-scaled-link
+     - .. include:: ../../shared/destination_settings.rst
+          :start-after: .. destinations-steps-validate-audience-start
+          :end-before: .. destinations-steps-validate-audience-end
+
+.. destination-eagle-eye-add-steps-end
+
+
+.. _destination-eagle-eye-validation:
+
+Data validation
+====================================================
+
+.. destination-eagle-eye-validation-start
+
+Amperity performs the configured operation for every row in the query results, except for rows it cannot process. A row is reported as failed, and the run continues, when any of the following is true:
+
+* The ``identity_value`` column is empty for that row.
+* The operation is **update** and the ``friendly_name`` column is empty for that row.
+* The operation is anything other than **create** and Eagle Eye has no wallet for that row's identity value.
+* Eagle Eye rejects that row's wallet payload, or the row targets a wallet that has already been terminated.
+
+Failed rows are reported in the destination's run details. Some conditions stop the entire run instead of failing individual rows: an unknown wallet operation, or a **state-change** send with no **Wallet state** set (both caught before any data is sent), and a rejected credential or Eagle Eye being unavailable.
+
+.. destination-eagle-eye-validation-end

--- a/amperity_operator/source/grid_destinations.rst
+++ b/amperity_operator/source/grid_destinations.rst
@@ -174,6 +174,10 @@ Set up connections to send data from Amperity to other marketing applications, t
       :link-type: doc
       :link: destination_dynamics_365_marketing
 
+   .. grid-item-card:: Eagle Eye
+      :link-type: doc
+      :link: destination_eagle_eye
+
    .. grid-item-card:: Epsilon Abacus
       :link-type: doc
       :link: destination_epsilon_abacus
@@ -485,6 +489,7 @@ Set up connections to send data from Amperity to other marketing applications, t
    Dynamic Yield <destination_dynamic_yield>
    Dynamic Yield Customer Profiles <destination_dynamic_yield_customer_profiles>
    Dynamics 365 Marketing <destination_dynamics_365_marketing>
+   Eagle Eye <destination_eagle_eye>
    Epsilon Abacus <destination_epsilon_abacus>
    Epsilon Conversant <destination_epsilon_conversant>
    Epsilon Targeting <destination_epsilon_targeting>

--- a/shared/credentials_settings.rst
+++ b/shared/credentials_settings.rst
@@ -2251,6 +2251,31 @@ Generate the API key in |destination-name| by navigating to **Settings > API Key
 
 .. credential-dynamic-yield-customer-profiles-api-find-key-end
 
+.. credential-eagle-eye-client-id-start
+
+The Eagle Eye AIR API client ID, provisioned by your Eagle Eye account manager. It identifies your Amperity integration to Eagle Eye and is not a secret.
+
+.. credential-eagle-eye-client-id-end
+
+.. credential-eagle-eye-client-secret-start
+
+The Eagle Eye AIR API secret paired with the Client ID, provisioned by your Eagle Eye account manager. Amperity uses it to authenticate each request.
+
+.. credential-eagle-eye-client-secret-end
+
+.. credential-eagle-eye-api-url-start
+
+The Eagle Eye AIR Wallet API base URL for your region and environment. Select the URL that matches your Eagle Eye company unit:
+
+* ``https://wallet.uk.eagleeye.com/2.0/`` (United Kingdom)
+* ``https://wallet.sandbox.uk.eagleeye.com/2.0/`` (United Kingdom sandbox)
+* ``https://wallet.au.eagleeye.com/2.0/`` (Australia)
+* ``https://wallet.us2.eagleeye.com/2.0/`` (United States)
+
+Confirm the correct URL with your Eagle Eye account manager. Defaults to the Australia URL.
+
+.. credential-eagle-eye-api-url-end
+
 **Username and password**
 
 .. credential-salesforce-sales-cloud-username-and-password-start

--- a/shared/destination_settings.rst
+++ b/shared/destination_settings.rst
@@ -2971,6 +2971,45 @@ The operation applied to every row in the query results: **upsert** (the default
 
 .. setting-dynamic-yield-customer-profiles-operation-end
 
+.. setting-eagle-eye-identity-type-start
+
+The name your Eagle Eye company unit uses for the loyalty identity carried in the ``identity_value`` column — for example ``CUSTOMER_ID`` or a loyalty card type. This is configured in Eagle Eye and differs by company unit, so confirm the exact name with your Eagle Eye account manager. Every wallet operation is addressed by this identity.
+
+.. setting-eagle-eye-identity-type-end
+
+.. setting-eagle-eye-default-wallet-type-start
+
+The Eagle Eye wallet type created for new wallets by the **create** operation. Defaults to **CONSUMER**, Eagle Eye's standard consumer wallet type. Change it only if your Eagle Eye company unit uses a different wallet type.
+
+.. setting-eagle-eye-default-wallet-type-end
+
+.. setting-eagle-eye-default-wallet-state-start
+
+The behavioral state applied to wallets created by the **create** operation. State values are configured per Eagle Eye company unit (for example ``EARNBURN``); a value your unit does not recognize is rejected. Leave this unset to let Eagle Eye apply your unit's default state — the safest choice unless your Eagle Eye account manager has confirmed the values your unit accepts.
+
+.. setting-eagle-eye-default-wallet-state-end
+
+.. setting-eagle-eye-operation-start
+
+The wallet operation performed for every row in the send. A send performs a single operation for the entire run:
+
+* **create** (the default) provisions a wallet for each person and attaches their loyalty identity, and sets the wallet's label from the ``friendly_name`` column when it is present. A person who already has a wallet is recovered rather than duplicated, so re-sending the same query results is safe.
+* **update** changes a wallet's friendly name, and requires the ``friendly_name`` column.
+* **state-change** changes a wallet's behavioral state, and requires the **Wallet state** setting below.
+* **suspend** temporarily halts a wallet's activity, and **activate** returns a suspended or inactive wallet to service.
+* **terminate** permanently closes a wallet. It is the path for consent-driven opt-out, cannot be undone, and Eagle Eye rejects any later change to a terminated wallet.
+* **delete** removes a wallet and is intended for cleaning up test data rather than for consent requests.
+
+Every operation other than **create** first looks up the person's existing wallet by their identity value; a person with no wallet yet is reported as a failed row and the run continues. You choose this operation when you configure the orchestration that sends to this destination.
+
+.. setting-eagle-eye-operation-end
+
+.. setting-eagle-eye-wallet-state-start
+
+The behavioral state applied by the **state-change** operation — for example ``EARNBURN`` or ``EARNONLY``. Required when the operation is **state-change**; Amperity stops the run with a message if it is missing. State values are configured per Eagle Eye company unit, so use only values your unit accepts. You choose this when you configure the orchestration that sends to this destination.
+
+.. setting-eagle-eye-wallet-state-end
+
 
 
 .. vale off

--- a/shared/terms.rst
+++ b/shared/terms.rst
@@ -2460,6 +2460,15 @@ Dynamics 365 Marketing helps you build personalized journeys for real-time and o
 .. term-dynamics-365-marketing-end
 
 
+**Eagle Eye**
+
+.. term-eagle-eye-start
+
+Eagle Eye is a loyalty and promotions platform. Its AIR platform manages loyalty wallets that track each customer's earning and spending activity in a loyalty program.
+
+.. term-eagle-eye-end
+
+
 **early repeat purchaser**, **early repeat purchasers**
 
 .. 


### PR DESCRIPTION
**Summary**

Add documentation for the Eagle Eye connector — a Beta egress/destination integration that manages Eagle Eye AIR loyalty wallets (create, update, state-change, suspend, activate, terminate, delete) from Amperity segments, one wallet operation per person per run. Modeled on the archetype-5 lookup-then-write destinations (Dynamic Yield Customer Profiles, Oracle Opera Outbound): destination-only, orchestration-driven, no campaign/audience-list concept.

**Included**

- New operator topic destination_eagle_eye.rst (context, wallet-operations table, get-details, credentials, add-destination, data-validation) and modal destination-eagle-eye.rst.
- Shared snippets: term-eagle-eye, three credential-eagle-eye-*, five setting-eagle-eye-*.
- Registration: destinations grid (card + toctree), modal index, base destinations.html card. Labeled Beta.

**Verification**

operator, modals, and base books all build clean with -W.

**Reviewer notes**

- Eagle Eye logo asset (connector-eagle-eye.svg) is not yet in _static (logo PR pending) — the destinations card image 404s until it lands.
- /app/ main has beta? true + work-in-progress? false with execute! implemented, so the docs are code-backed as Beta; hold merge if main isn't yet what ships.