### PR TITLE
List journey_create and fix the stale node-schema tool name

### DIFF
--- a/amperity_api/source/mcp_tool_reference.rst
+++ b/amperity_api/source/mcp_tool_reference.rst
@@ -569,6 +569,8 @@ Manage campaigns, campaign folders, journeys, and audiences.
 
        **journey_get**
 
+       **journey_create**
+
        **journey_delete**
 
    * - Manage journey versions
@@ -587,8 +589,8 @@ Manage campaigns, campaign folders, journeys, and audiences.
 
        **journey_unschedule**
 
-   * - Read a journey's node schema
-     - **journey_get_node_schema**
+   * - Read the journey authoring reference
+     - **journey_get_authoring_reference**
 
 
 .. _mcp-tool-data-exports:


### PR DESCRIPTION
## Summary

Two corrections to the MCP tool catalog in `amperity_api/source/mcp_tool_reference.rst`.

`journey_create` moved to the externally available tool set in the MCP server (amperity/app#72397), where it now creates a journey together with its first version graph in one call. The catalog omitted it, so the entry point of the journey build sequence was invisible to customers reading this page.

`journey_get_node_schema` no longer exists. It was replaced by `journey_get_authoring_reference`, which serves the authoring guide, the node field reference, and the graph templates. That row was stale independent of the change above.

## Changes

- Add **journey_create** to the "Manage journeys" row.
- Rename the last row to "Read the journey authoring reference" and point it at **journey_get_authoring_reference**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
